### PR TITLE
Add support for time filter in appdynamics log query

### DIFF
--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -52,13 +52,14 @@ def test_elasticsearch_search(monkeypatch):
     url = 'http://es/'
     es = ElasticsearchWrapper(url)
 
-    result = es.search()
+    q = 'my-search'
+    result = es.search(q=q)
 
     assert result == resp.json.return_value
 
     get.assert_called_with(get_full_url(url),
                            headers={'User-Agent': get_user_agent()},
-                           params={'q': '', 'size': DEFAULT_SIZE, '_source': 'true'},
+                           params={'q': q, 'size': DEFAULT_SIZE, '_source': 'true'},
                            timeout=10)
 
 
@@ -70,13 +71,14 @@ def test_elasticsearch_count(monkeypatch):
     url = 'http://es/'
     es = ElasticsearchWrapper(url)
 
-    result = es.count()
+    q = 'status:404'
+    result = es.count(q=q)
 
     assert result == resp.json.return_value
 
     get.assert_called_with(get_full_url(url, query_type=TYPE_COUNT),
                            headers={'User-Agent': get_user_agent()},
-                           params={'q': ''},
+                           params={'q': q},
                            timeout=10)
 
 
@@ -89,13 +91,14 @@ def test_elasticsearch_search_multiple_indices(monkeypatch):
     es = ElasticsearchWrapper(url)
 
     indices = ['logstash-2016-*', 'logstash-2015-*']
-    result = es.search(indices=indices)
+    q = 'my-search'
+    result = es.search(indices=indices, q=q)
 
     assert result == resp.json.return_value
 
     get.assert_called_with(get_full_url(url, indices=indices),
                            headers={'User-Agent': get_user_agent()},
-                           params={'q': '', 'size': DEFAULT_SIZE, '_source': 'true'},
+                           params={'q': q, 'size': DEFAULT_SIZE, '_source': 'true'},
                            timeout=10)
 
 
@@ -115,6 +118,7 @@ def test_elasticsearch_search_body(monkeypatch):
     body['size'] = DEFAULT_SIZE
 
     post.assert_called_with(get_full_url(url),
+                            params={},
                             json=body,
                             headers={'User-Agent': get_user_agent()},
                             timeout=10)
@@ -138,6 +142,7 @@ def test_elasticsearch_search_multiple_indices_body(monkeypatch):
     body['size'] = DEFAULT_SIZE
 
     post.assert_called_with(get_full_url(url, indices=indices),
+                            params={},
                             json=body,
                             headers={'User-Agent': get_user_agent()},
                             timeout=10)
@@ -157,7 +162,7 @@ def test_elasticsearch_search_no_source_with_size(monkeypatch):
 
     get.assert_called_with(get_full_url(url),
                            headers={'User-Agent': get_user_agent()},
-                           params={'q': '', 'size': 100, '_source': 'false'},
+                           params={'size': 100, '_source': 'false'},
                            timeout=10)
 
 
@@ -180,6 +185,7 @@ def test_elasticsearch_search_no_source_body_with_size(monkeypatch):
     body['_source'] = False
 
     post.assert_called_with(get_full_url(url, indices=indices),
+                            params={},
                             json=body,
                             headers={'User-Agent': get_user_agent()},
                             timeout=10)
@@ -203,7 +209,7 @@ def test_elasticsearch_search_oauth2(monkeypatch):
 
     get.assert_called_with(get_full_url(url),
                            headers={'User-Agent': get_user_agent(), 'Authorization': 'Bearer {}'.format(token)},
-                           params={'q': '', 'size': DEFAULT_SIZE, '_source': 'true'},
+                           params={'size': DEFAULT_SIZE, '_source': 'true'},
                            timeout=10)
 
 

--- a/zmon_worker_monitor/builtins/plugins/elasticsearch.py
+++ b/zmon_worker_monitor/builtins/plugins/elasticsearch.py
@@ -138,8 +138,11 @@ class ElasticsearchWrapper(object):
 
         url = os.path.join(self.url, indices_str, query_type)
 
+        params = {}
+        if q:
+            params['q'] = q
+
         if body is None:
-            params = {'q': q}
             if query_type == TYPE_SEARCH:
                 params['size'] = size
                 params['_source'] = str(source).lower()
@@ -152,7 +155,7 @@ class ElasticsearchWrapper(object):
                 if source is False and '_source' not in body:
                     body['_source'] = False
 
-            return self.__request(url, body=body)
+            return self.__request(url, params=params, body=body)
 
     def health(self):
         """Return ES cluster health."""
@@ -174,7 +177,7 @@ class ElasticsearchWrapper(object):
 
                 return response.json()
             else:
-                response = requests.post(url, json=body, timeout=self.timeout, headers=self._headers)
+                response = requests.post(url, params=params, json=body, timeout=self.timeout, headers=self._headers)
 
                 if not response.ok:
                     raise Exception(


### PR DESCRIPTION
+ duration_in_mins before now. default is 5 mins.
+ Update elasticsearch plugin to always pass params as it affects query even when POST is used.