### PR TITLE
Adding support for setting seed nodes for cassandra wrapper

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
@@ -33,7 +33,7 @@ class CassandraFactory(IFunctionFactoryPlugin):
         :return: an object that implements a check function
         """
 
-        if factory_ctx.get('entity', {}).get('seeds') is not None:
+        if factory_ctx.get('entity', {}).get('seeds'):
             return propartial(CassandraWrapper,
                               node=factory_ctx.get('entity', {}).get('seeds'),
                               username=self._username,
@@ -47,11 +47,8 @@ class CassandraWrapper(object):
     def __init__(self, node, keyspace, username=None, password=None, port=9042, connect_timeout=1, protocol_version=3):
         # for now using a single host / node should be seed nodes or at least available nodes
 
-        if node is not None and not isinstance(node, list):
-            if "," in node:
-                seeds = node.split(",")
-            else:
-                seeds = [node]
+        if node and not isinstance(node, list):
+            seeds = node.split(",")
         else:
             seeds = node
 

--- a/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
@@ -33,14 +33,8 @@ class CassandraFactory(IFunctionFactoryPlugin):
         :return: an object that implements a check function
         """
 
-        if factory_ctx.get('entity', {}).get('seeds'):
-            return propartial(CassandraWrapper,
-                              node=factory_ctx.get('entity', {}).get('seeds'),
-                              username=self._username,
-                              password=self._password)
-
-        return propartial(
-            CassandraWrapper, node=factory_ctx.get('host'), username=self._username, password=self._password)
+        seeds = factory_ctx.get('entity', {}).get('seeds') or factory_ctx.get('host')
+        return propartial(CassandraWrapper, node=seeds, username=self._username, password=self._password)
 
 
 class CassandraWrapper(object):


### PR DESCRIPTION
Add support for cassandra cluster entities containing list of seed nodes:

```
type: cassandra-cluster
name: my-cluster
seeds:
  - ip1
  - ip2
```
