### PR TITLE
fix counter().per_minute (must be per_second * 60!)

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/counter.py
+++ b/zmon_worker_monitor/builtins/plugins/counter.py
@@ -67,9 +67,9 @@ class CounterWrapper(object):
         return result
 
     def per_minute(self, value):
-        '''convenience method: returns per_second(..) / 60'''
+        '''convenience method: returns per_second(..) * 60'''
 
-        return self.per_second(value) / 60.0
+        return self.per_second(value) * 60.0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix a stupid bug (apparently everybody used per_second...).