### PR TITLE
Specify tests path in py_test args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class PyTest(TestCommand):
     def initialize_options(self):
         TestCommand.initialize_options(self)
         self.cov = None
-        self.pytest_args = ['--cov', MAIN_PACKAGE, '--cov-report', 'term-missing',
+        self.pytest_args = ['tests/', '--cov', MAIN_PACKAGE, '--cov-report', 'term-missing',
                             '--doctest-modules', '-s', '-v',
                             '--ignore', 'tests/plugins']
         self.cov_html = False


### PR DESCRIPTION
otherwise tests break if executed using a 'virtual 'environment'

see: https://github.com/pytest-dev/pytest-django/issues/102