### PR TITLE
Adding Logging and Exception handling for S3 plugin

### DIFF
--- a/zmon_worker_monitor/zmon_worker/errors.py
+++ b/zmon_worker_monitor/zmon_worker/errors.py
@@ -64,3 +64,10 @@ class ResultSizeError(CheckError):
         message = 'Result size error: {}'.format(message)
 
         super(ResultSizeError, self).__init__(message)
+
+
+class S3BotoClientError(CheckError):
+    def __init__(self, message):
+        message = 'Boto Client Error: {}'.format(message)
+
+        super(S3BotoClientError, self).__init__(message)


### PR DESCRIPTION
Added exception handling as when zmon-agent doesn't have necessary permission on the bucket, it silently returns -1 for size. Which misleads a user and doesn't provide a correct feedback.