### PR TITLE
add openam() check (#205)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,3 +56,5 @@ plugin.mssql.pass: '--secret--'
 plugin.elasticsearch.url: 'https://es-cluster'
 
 plugin.appdynamics.url: 'https://appdynamics'
+
+plugin.openam.url: 'https://auth.zalando.com/z'

--- a/zmon_worker_extras/check_plugins/openam.py
+++ b/zmon_worker_extras/check_plugins/openam.py
@@ -16,7 +16,7 @@ class OpenAMFactory(IFunctionFactoryPlugin):
         Called after plugin is loaded to pass the [configuration] section in their plugin info file
         :param conf: configuration dictionary
         """
-        self.openam_base_url = config.get('url')
+        self.openam_base_url = conf.get('url')
         return
 
     def create(self, factory_ctx):

--- a/zmon_worker_extras/check_plugins/openam.py
+++ b/zmon_worker_extras/check_plugins/openam.py
@@ -7,6 +7,7 @@ import os
 from zmon_worker_monitor.zmon_worker.errors import CheckError
 from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
 
+
 class OpenAMFactory(IFunctionFactoryPlugin):
     def __init__(self):
         super(OpenAMFactory, self).__init__()
@@ -28,6 +29,7 @@ class OpenAMFactory(IFunctionFactoryPlugin):
         :return: an object that implements a check function
         """
         return propartial(OpenAMWrapper, url=self.openam_base_url, user=self.username, password=self.__password)
+
 
 class OpenAMError(CheckError):
     def __init__(self, message):
@@ -67,9 +69,19 @@ class OpenAMWrapper(object):
             self.params.update({"service": chain})
             self.params.update({"authIndexType": "service"})
             self.params.update({"authIndexValue": chain})
-        self.headers.update({"X-OpenAM-Username": user, "X-OpenAM-Password": password, "Content-Type": "application/json"})
+        self.headers.update({
+            "X-OpenAM-Username": user,
+            "X-OpenAM-Password": password,
+            "Content-Type": "application/json",
+        })
         try:
-            r = requests.post(self.url + "/json/authenticate", params=self.params, headers=self.headers, json={}, allow_redirects=False)
+            r = requests.post(
+                self.url + "/json/authenticate",
+                params=self.params,
+                headers=self.headers,
+                json={},
+                allow_redirects=False,
+            )
         except Exception, e:
             raise OpenAMError("failed to call OpenAM: "+str(e))
 
@@ -83,6 +95,7 @@ class OpenAMWrapper(object):
         result["duration"] = r.elapsed.total_seconds()
         result["code"] = r.status_code
         return result
+
 
 if __name__ == '__main__':
     import sys
@@ -99,5 +112,9 @@ if __name__ == '__main__':
     factory_ctx = {}
 
     # eventlog = EventLogWrapper()
-    openam = OpenAMWrapper(openam_url, user=os.getenv("OPENAM_USER"), password=os.getenv("OPENAM_PASSWORD")).auth(realm="/employees", chain="EmployeeChain")
+    openam = OpenAMWrapper(
+        openam_url,
+        user=os.getenv("OPENAM_USER"),
+        password=os.getenv("OPENAM_PASSWORD")
+    ).auth(realm="/employees", chain="EmployeeChain")
     print(openam)

--- a/zmon_worker_extras/check_plugins/openam.py
+++ b/zmon_worker_extras/check_plugins/openam.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import requests
+import os
+
+from zmon_worker_monitor.zmon_worker.errors import CheckError
+from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
+
+class OpenAMFactory(IFunctionFactoryPlugin):
+    def __init__(self):
+        super(OpenAMFactory, self).__init__()
+
+    def configure(self, conf):
+        """
+        Called after plugin is loaded to pass the [configuration] section in their plugin info file
+        :param conf: configuration dictionary
+        """
+        self.openam_base_url = config.get('url')
+        return
+
+    def create(self, factory_ctx):
+        """
+        Automatically called to create the check function's object
+        :param factory_ctx: (dict) names available for Function instantiation
+        :return: an object that implements a check function
+        """
+        return propartial(OpenAMWrapper, url=self.openam_base_url)
+
+class OpenAMError(CheckError):
+    def __init__(self, message):
+        self.message = message
+        super(OpenAMError, self).__init__()
+
+    def __str__(self):
+        return 'OpenAM Error. Message: {}'.format(self.message)
+
+
+class OpenAMWrapper(object):
+    def __init__(
+            self,
+            url,
+            params=None,
+            timeout=10,
+            max_retries=0,
+            verify=True,
+            headers=None,
+            ):
+        self.url = url
+        self.params = params or {}
+        self.headers = headers or {}
+
+    def auth(self, chain=None, realm=None, user=os.getenv("OPENAM_USER"), password=os.getenv("OPENAM_PASSWORD")):
+        if not user or user == "":
+            raise OpenAMError("missing user")
+        if not password or password == "":
+            raise OpenAMError("missing password")
+        if realm:
+            self.params.update({"realm": realm})
+        if chain:
+            self.params.update({"service": chain})
+            self.params.update({"authIndexType": "service"})
+            self.params.update({"authIndexValue": chain})
+        self.headers.update({"X-OpenAM-Username": user, "X-OpenAM-Password": password, "Content-Type": "application/json"})
+        try:
+            r = requests.post(self.url + "/json/authenticate", params=self.params, headers=self.headers, json={}, allow_redirects=False)
+        except Exception, e:
+            raise OpenAMError("failed to call OpenAM: "+str(e))
+
+        try:
+            data = r.json()
+        except Exception, e:
+            raise OpenAMError("failed to parse OpenAM json: "+str(e))
+
+        result = {}
+        result["success"] = 'tokenId' in data
+        result["duration"] = r.elapsed.total_seconds()
+        result["code"] = r.status_code
+        return result
+
+if __name__ == '__main__':
+    import sys
+    import logging
+    from zmon_worker_monitor import plugin_manager
+
+    logging.basicConfig(level=logging.INFO)
+
+    # init plugin manager and collect plugins, as done by Zmon when worker is starting
+    plugin_manager.init_plugin_manager()
+    plugin_manager.collect_plugins(load_builtins=True, load_env=True)
+
+    openam_url = sys.argv[1]
+    factory_ctx = {}
+
+    # eventlog = EventLogWrapper()
+    openam = OpenAMWrapper(openam_url).auth(realm="/employees", chain="EmployeeChain")
+    print(openam)

--- a/zmon_worker_extras/check_plugins/openam.worker_plugin
+++ b/zmon_worker_extras/check_plugins/openam.worker_plugin
@@ -3,10 +3,10 @@ Name = openam
 Module = openam
 
 [Documentation]
-Author = John Doe
+Author = Hanno Hecker
 Version = 0.1
 Website = https://github.com/zalando/zmon-worker
-Description = Builtin plugin that provides an http request check function.
+Description = Builtin plugin that provides an openam request check function.
 
 
 [Configuration]

--- a/zmon_worker_extras/check_plugins/openam.worker_plugin
+++ b/zmon_worker_extras/check_plugins/openam.worker_plugin
@@ -1,0 +1,18 @@
+[Core]
+Name = openam
+Module = openam
+
+[Documentation]
+Author = John Doe
+Version = 0.1
+Website = https://github.com/zalando/zmon-worker
+Description = Builtin plugin that provides an http request check function.
+
+
+[Configuration]
+
+;; The configuration section is optional, you can put here any parameters needed to configure the plugin.
+;; Note that these values may are overridden by zmon's global config.
+;; key = valueX
+;; Note valueX will be overridden if Zmon's global config has: plugin.{plugin_name}.{key} = valueY
+url = https://openam.example.com/openam


### PR DESCRIPTION
Check usage:
        openam().auth(chain="SomeChain", realm="/employees")

Username and password for the authentication are taken from
ZMONs (docker) environment.