### PR TITLE
Fix regular expression to match PostgreSQL connection string

### DIFF
--- a/tests/test_sql_postgresql.py
+++ b/tests/test_sql_postgresql.py
@@ -19,7 +19,7 @@ STMT = 'SELECT * FROM X'
         [{'col1': 1, 'col2': 2, 'col3': 3}] * RESULT_COUNT,
     ),
     (
-        {'shards': {'shard-1': 'pg-host:5432/db'}, 'shard': 'shard-1', 'created_by': 'zmon'},
+        {'shards': {'shard-1': 'pg-host:5432/db-2'}, 'shard': 'shard-1', 'created_by': 'zmon'},
         {'col1': 1, 'col2': 2, 'col3': 3},
         {'col1': 1, 'col2': 2, 'col3': 3},
         [{'col1': 1, 'col2': 2, 'col3': 3}] * RESULT_COUNT,

--- a/zmon_worker_monitor/builtins/plugins/sql_postgresql.py
+++ b/zmon_worker_monitor/builtins/plugins/sql_postgresql.py
@@ -15,7 +15,7 @@ CONNECTION_RE = \
     re.compile(r'''
 ^(?P<host>[^:/]+)       # host - either IP o hostname
 (:(?P<port>\d+))?       # port - integer, optional
-/(?P<dbname>\S+)        # database name
+/(?P<dbname>[^/]\S*)    # database name - allow punctuation, but not leading slash
 $
 ''', re.X)
 

--- a/zmon_worker_monitor/builtins/plugins/sql_postgresql.py
+++ b/zmon_worker_monitor/builtins/plugins/sql_postgresql.py
@@ -15,7 +15,7 @@ CONNECTION_RE = \
     re.compile(r'''
 ^(?P<host>[^:/]+)       # host - either IP o hostname
 (:(?P<port>\d+))?       # port - integer, optional
-/(?P<dbname>\w+)        # database name
+/(?P<dbname>\S+)        # database name
 $
 ''', re.X)
 


### PR DESCRIPTION
Previously it would break if the database name contains some punctuation chars
such as '-'.