### PR TITLE
Direct connection using the EXASOL driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "2.7"
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y libsnappy-dev libev4 libev-dev python-dev
+  - sudo apt-get install -y libsnappy-dev libev4 libev-dev python-dev libboost-all-dev unixodbc-dev
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 cache: "pip"
 sudo: required

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,25 @@ FROM registry.opensource.zalan.do/stups/ubuntu:16.04-49
 
 #making this a cachable point as compile takes forever without -j
 
-RUN apt-get update && apt-get -y install python-pip python-dev libev4 libev-dev python-psycopg2 libpq-dev libldap2-dev libsasl2-dev libssl-dev libsnappy-dev iputils-ping && \
-    pip2 install -U pip setuptools urllib3 Cython
+RUN apt-get update && \
+    apt-get -y install iputils-ping \
+                       libboost-all-dev \
+                       libev4 \
+                       libev-dev \
+                       libldap2-dev \
+                       libpq-dev \
+                       libsasl2-dev \
+                       libsnappy-dev \
+                       libssl-dev \
+                       python-dev \
+                       python-pip \
+                       python-psycopg2 \
+                       unixodbc-dev && \
+    pip2 install -U pip Cython \
+                        setuptools \
+                        urllib3
+
+
 
 # make requests library use the Debian CA bundle (includes Zalando CA)
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,5 @@ stups-tokens>=1.0.14
 subprocess32
 timeperiod2==0.1
 Yapsy>=1.10.423
+pybind11
 turbodbc>=1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ stups-tokens>=1.0.14
 subprocess32
 timeperiod2==0.1
 Yapsy>=1.10.423
+turbodbc>=1.1.2

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -233,8 +233,8 @@ class TestPluginManager(unittest.TestCase):
                             'plugin object is instance of IFunctionFactoryPlugin')
 
         # test extra plugin are configured according to config file
-        self.assertEqual(plugin_manager.get_plugin_obj_by_name('exasol', 'Function')._exasol_driver,
-                         '--path to EXASOL driver--', 'exasol object is configured')
+        self.assertEqual(plugin_manager.get_plugin_obj_by_name('exasol', 'Function')._exasol_pass,
+                         '--secret--', 'exasol object is configured')
 
     @patch.dict(os.environ, {'ZMON_PLUGINS': simple_plugin_dir_abs_path()})
     def test_global_config(self):

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -233,8 +233,8 @@ class TestPluginManager(unittest.TestCase):
                             'plugin object is instance of IFunctionFactoryPlugin')
 
         # test extra plugin are configured according to config file
-        self.assertEqual(plugin_manager.get_plugin_obj_by_name('exacrm', 'Function')._exacrm_cluster, '--secret--',
-                         'exacrm object is configured')
+        self.assertEqual(plugin_manager.get_plugin_obj_by_name('exasol', 'Function')._exasol_driver,
+                         '--path to EXASOL driver--', 'exasol object is configured')
 
     @patch.dict(os.environ, {'ZMON_PLUGINS': simple_plugin_dir_abs_path()})
     def test_global_config(self):

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -214,7 +214,7 @@ class TestPluginManager(unittest.TestCase):
                         'found at least 2 categories and they all belong to all defined categories')
 
         # check known test plugins are loaded
-        extra_plugins = ['exacrm', 'job_lock', 'nagios', 'snmp', 'mssql']  # non exhaustive list
+        extra_plugins = ['exasol', 'job_lock', 'nagios', 'snmp', 'mssql']  # non exhaustive list
         known_plugin_names = extra_plugins + ['http', 'color_spain', 'color_germany', 'temperature_fridge']
         plugin_names = plugin_manager.get_all_plugin_names()
         self.assertTrue(set(known_plugin_names).issubset(plugin_names), 'All known test plugins are loaded')

--- a/zmon_worker_extras/check_plugins/exasol.py
+++ b/zmon_worker_extras/check_plugins/exasol.py
@@ -9,6 +9,7 @@ from turbodbc import connect
 
 EXASOL_DRIVER_LOCATION = '/var/lib/zmon/exasol/cd gitlibexaodbc.so'
 
+
 class ExaplusFactory(IFunctionFactoryPlugin):
     def __init__(self):
         super(ExaplusFactory, self).__init__()

--- a/zmon_worker_extras/check_plugins/exasol.py
+++ b/zmon_worker_extras/check_plugins/exasol.py
@@ -4,9 +4,8 @@
 Query Exasol
 """
 
-import tempfile
-import subprocess
-import os
+
+
 
 from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
 from turbodbc import connect

--- a/zmon_worker_extras/check_plugins/exasol.py
+++ b/zmon_worker_extras/check_plugins/exasol.py
@@ -4,9 +4,6 @@
 Query Exasol
 """
 
-
-
-
 from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
 from turbodbc import connect
 

--- a/zmon_worker_extras/check_plugins/exasol.py
+++ b/zmon_worker_extras/check_plugins/exasol.py
@@ -7,7 +7,7 @@ Query Exasol
 from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
 from turbodbc import connect
 
-EXASOL_DRIVER_LOCATION = '/var/lib/zmon/exasol/cd gitlibexaodbc.so'
+EXASOL_DRIVER_LOCATION = '/var/lib/zmon/exasol/libexaodbc.so'
 
 
 class ExaplusFactory(IFunctionFactoryPlugin):

--- a/zmon_worker_extras/check_plugins/exasol.py
+++ b/zmon_worker_extras/check_plugins/exasol.py
@@ -9,24 +9,25 @@ import subprocess
 import os
 
 from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
+from turbodbc import connect
 
 
 class ExaplusFactory(IFunctionFactoryPlugin):
     def __init__(self):
         super(ExaplusFactory, self).__init__()
         # fields from config
-        self._exacrm_cluster = None
-        self._exacrm_user = None
-        self._exacrm_pass = None
+        self._exasol_user = None
+        self._exasol_pass = None
+        self._exasol_driver = None
 
     def configure(self, conf):
         """
         Called after plugin is loaded to pass the [configuration] section in their plugin info file
         :param conf: configuration dictionary
         """
-        self._exacrm_cluster = conf['exacrm_cluster']
-        self._exacrm_user = conf['exacrm_user']
-        self._exacrm_pass = conf['exacrm_pass']
+        self._exasol_user = conf['exasol_user']
+        self._exasol_pass = conf['exasol_pass']
+        self._exasol_driver = conf['exasol_driver']
 
     def create(self, factory_ctx):
         """
@@ -34,59 +35,54 @@ class ExaplusFactory(IFunctionFactoryPlugin):
         :param factory_ctx: (dict) names available for Function instantiation
         :return: an object that implements a check function
         """
-        return propartial(ExaplusWrapper, cluster=self._exacrm_cluster, password=self._exacrm_pass,
-                          user=self._exacrm_user)
+        return propartial(ExaplusWrapper, cluster=factory_ctx['cluster'], password=self._exasol_pass,
+                          user=self._exasol_user, schema=factory_ctx['schema'],
+                          driver=self._exasol_driver)
 
 
 class ExaplusWrapper(object):
-    def __init__(self, cluster, user='ZALANDO_NAGIOS', password='', schema=False):
+    def __init__(self, cluster, user='', password='', schema='', driver=''):
         self._err = None
         self._out = None
         self.user = user
         self.__password = password
         self.cluster = cluster
         self.schema = schema
-        self.java_opts = ['-Djava.net.preferIPv4Stack=true', '-Djava.awt.headless=true', '-Xmx512m', '-Xms128m']
-        self.exaplus_opts = [
-            '-recoverConnection',
-            'OFF',
-            '-retry',
-            '0',
-            '-lang',
-            'EN',
-            '-q',
-            '-x',
-            '-Q',
-            '10',
-            '-pipe',
-        ]
-        self.jar_file = '/server/exasol/exaplus/current/exaplus.jar'
+        self.driver = driver
 
     def query(self, query):
-        fd, name = tempfile.mkstemp(suffix='.sql', text=True)
         try:
-            fh = os.fdopen(fd, 'w')
-            fh.write('%s\n' % query)
-            fh.flush()
+            connection = connect(
+                driver=self.driver,
+                EXAHOST=self.cluster,
+                EXASCHEMA=self.schema,
+                EXAUID=self.user,
+                EXAPWD=self.__password)
+            cursor = connection.cursor()
 
-            cmd = ['/usr/bin/java']
-            cmd.extend(self.java_opts)
-            cmd.extend(['-jar', self.jar_file])
-            cmd.extend(['-c', self.cluster])
-            cmd.extend(['-u', self.user])
-            cmd.extend(['-p', self.__password])
-            cmd.extend(self.exaplus_opts)
-            if self.schema:
-                cmd.extend(['-s', self.schema])
-            cmd.extend(['-f', name])
-            # print "EXAPLUS="+" ".join(cmd)
-            sub = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True)
-            d_out, d_err = sub.communicate()
-            self._out = d_out
-            self._err = d_err
-        finally:
-            os.unlink(name)
+            cursor.execute(query)
+            self._out = cursor
+
+        except Exception as err:
+            self._err = err
+
         return self
 
     def result(self):
-        return self._out.split('\n'), self._err.split('\n')
+        columns = []
+        values = []
+
+        if self._out:
+            # get_headers
+            for col in self._out.description:
+                columns.append(col[0])
+
+            # get_values
+            value = {}
+
+            for row in self._out:
+                for i, col in enumerate(columns):
+                    value[col] = row[i]
+                values.append(value)
+
+        return values, self._err

--- a/zmon_worker_extras/check_plugins/exasol.worker_plugin
+++ b/zmon_worker_extras/check_plugins/exasol.worker_plugin
@@ -18,7 +18,5 @@ Description = Builtin plugin that provides an http request check function.
 
 exasol_user = user
 exasol_pass = --secret--
-exasol_driver = --path to EXASOL driver--
-;; exasol_driver = /usr/me/projects/testodbc/lib/EXASolution_ODBC-5.0.18/lib/linux/x86_64/libexaodbc-uo2214lv2.so
 exasol_schema = EXA_STATISTICS
 

--- a/zmon_worker_extras/check_plugins/exasol.worker_plugin
+++ b/zmon_worker_extras/check_plugins/exasol.worker_plugin
@@ -1,5 +1,5 @@
 [Core]
-Name = exacrm
+Name = exasol
 Module = exasol
 
 [Documentation]
@@ -16,7 +16,9 @@ Description = Builtin plugin that provides an http request check function.
 ;; key = valueX
 ;; Note valueX will be overridden if Zmon's global config has: plugin.{plugin_name}.{key} = valueY
 
+exasol_user = user
+exasol_pass = --secret--
+exasol_driver = --enter here path for the EXASOL driver --
+;; exasol_driver = /usr/me/projects/testodbc/lib/EXASolution_ODBC-5.0.18/lib/linux/x86_64/libexaodbc-uo2214lv2.so
+exasol_schema = EXA_STATISTICS
 
-exacrm_cluster = --secret--
-exacrm_user = user
-exacrm_pass = --secret--

--- a/zmon_worker_extras/check_plugins/exasol.worker_plugin
+++ b/zmon_worker_extras/check_plugins/exasol.worker_plugin
@@ -18,5 +18,4 @@ Description = Builtin plugin that provides an http request check function.
 
 exasol_user = user
 exasol_pass = --secret--
-exasol_schema = EXA_STATISTICS
 

--- a/zmon_worker_extras/check_plugins/exasol.worker_plugin
+++ b/zmon_worker_extras/check_plugins/exasol.worker_plugin
@@ -18,7 +18,7 @@ Description = Builtin plugin that provides an http request check function.
 
 exasol_user = user
 exasol_pass = --secret--
-exasol_driver = --enter here path for the EXASOL driver --
+exasol_driver = --path to EXASOL driver--
 ;; exasol_driver = /usr/me/projects/testodbc/lib/EXASolution_ODBC-5.0.18/lib/linux/x86_64/libexaodbc-uo2214lv2.so
 exasol_schema = EXA_STATISTICS
 


### PR DESCRIPTION
Problem: ZMON is connecting to EXASOL using a command line tool. The query result is just a list of string, better to have it in json.

Solution: Wrapper uses now Turbodbc to connect, the EXASOL driver location is in the config file.

Additional things: The cluster is now coming from the entity definition. Removed references to exacrm, now everything is just exasol.