### PR TITLE
Add kairosdb support for start_absolute and end_absolute

### DIFF
--- a/tests/test_kairosdb.py
+++ b/tests/test_kairosdb.py
@@ -27,6 +27,10 @@ URL = 'http://kairosdb'
         {'queries': [{'results': [1, 2, 3, 4, 5, 6, 7, 8]}]},
     ),
     (
+        {'name': 'check1-metric', 'aggregators': [{'name': 'sum'}], 'start_absolute': 1498049043491, 'end_absolute': 0},
+        {'queries': [{'results': [1, 2, 3, 4, 5, 6, 7, 8]}]}
+    ),
+    (
         {'name': 'check1-metric'},
         requests.Timeout(),
     ),
@@ -81,22 +85,27 @@ def get_query(kwargs):
     time_unit = kwargs.get('time_unit', 'minutes')
     group_by = kwargs.get('group_by', [])
 
-    q = {
-        'start_relative': {
+    q = {'metrics': [{
+        'name': kwargs['name'],
+        'group_by': group_by
+    }]}
+
+    if 'start_absolute' in kwargs:
+        q['start_absolute'] = kwargs['start_absolute']
+    else:
+        q['start_relative'] = {
             'value': start,
             'unit': time_unit
-        },
-        'metrics': [{
-            'name': kwargs['name'],
-            'group_by': group_by
-        }]
-    }
-
-    if 'end' in kwargs:
-        q['end_relative'] = {
-            'value': kwargs['end'],
-            'unit': time_unit
         }
+
+    if 'end_absolute' in kwargs:
+        q['end_absolute'] = kwargs['end_absolute']
+    else:
+        if 'end' in kwargs:
+            q['end_relative'] = {
+                'value': kwargs['end'],
+                'unit': time_unit
+            }
 
     if 'aggregators' in kwargs:
         q['metrics'][0]['aggregators'] = kwargs.get('aggregators')

--- a/zmon_worker_monitor/builtins/plugins/kairosdb.py
+++ b/zmon_worker_monitor/builtins/plugins/kairosdb.py
@@ -58,7 +58,8 @@ class KairosdbWrapper(object):
         if oauth2:
             self.__session.headers.update({'Authorization': 'Bearer {}'.format(tokens.get('uid'))})
 
-    def query(self, name, group_by=None, tags=None, start=5, end=0, time_unit='minutes', aggregators=None):
+    def query(self, name, group_by=None, tags=None, start=5, end=0, time_unit='minutes', aggregators=None,
+              start_absolute=None, end_absolute=None):
         """
         Query kairosdb.
 
@@ -83,6 +84,12 @@ class KairosdbWrapper(object):
         :param aggregators: List of aggregators.
         :type aggregators: list
 
+        :param start_absolute: Absolute start time in milliseconds, overrides the start parameter which is relative
+        :type start_absolute: long
+
+        :param end_absolute: Absolute end time in milliseconds, overrides the end parameter which is relative
+        :type end_absolute: long
+
         :return: Result queries.
         :rtype: dict
         """
@@ -94,22 +101,27 @@ class KairosdbWrapper(object):
         if group_by is None:
             group_by = []
 
-        q = {
-            'start_relative': {
+        q = {'metrics': [{
+            'name': name,
+            'group_by': group_by
+        }]}
+
+        if start_absolute is None:
+            q['start_relative'] = {
                 'value': start,
                 'unit': time_unit
-            },
-            'metrics': [{
-                'name': name,
-                'group_by': group_by
-            }]
-        }
-
-        if end > 0:
-            q['end_relative'] = {
-                'value': end,
-                'unit': time_unit
             }
+        else:
+            q['start_absolute'] = start_absolute
+
+        if end_absolute is None:
+            if end > 0:
+                q['end_relative'] = {
+                    'value': end,
+                    'unit': time_unit
+                }
+        else:
+            q['end_absolute'] = end_absolute
 
         if aggregators:
             q['metrics'][0]['aggregators'] = aggregators


### PR DESCRIPTION
Adding support for the kariosdb helper to allow passing a
'start_absolute' and 'end_absolute' into the query as per
https://kairosdb.github.io/docs/build/html/restapi/QueryMetrics.html

Defaults stay the same, should start_absolute or end_absolute be set
they will override the relative start and end respectively.

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>