### PR TITLE
Paginate results for 1000+ files

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -122,7 +122,7 @@ def test_listing_on_existing_prefix(monkeypatch):
 
     def writer_side_effect(*args, **kwargs):
         return {'Contents': [{'Key': 'some_file', 'Size': 123, 'LastModified': datetime(2015, 1, 15, 14, 34, 56)}]}
-    client.list_objects_v2.side_effect = writer_side_effect
+    client.get_paginator.return_value.paginate.return_value.build_full_result.side_effect = writer_side_effect
     get = MagicMock()
     get.return_value.json.return_value = {'region': 'eu-central-1'}
     monkeypatch.setattr('requests.get', get)
@@ -147,7 +147,7 @@ def test_listing_on_prefix_that_has_no_objects(monkeypatch):
 
     def writer_side_effect(*args, **kwargs):
         return {}
-    client.list_objects_v2.side_effect = writer_side_effect
+    client.get_paginator.return_value.paginate.return_value.build_full_result.side_effect = writer_side_effect
     get = MagicMock()
     get.return_value.json.return_value = {'region': 'eu-central-1'}
     monkeypatch.setattr('requests.get', get)
@@ -165,7 +165,7 @@ def test_listing_bubbles_client_error_up(monkeypatch):
 
     def writer_side_effect(*args, **kwargs):
         raise ClientError({'Error': {'Code': 403, 'Message': 'Access denied'}}, 'information')
-    client.list_objects_v2.side_effect = writer_side_effect
+    client.get_paginator.return_value.paginate.side_effect = writer_side_effect
     get = MagicMock()
     get.return_value.json.return_value = {'region': 'eu-central-1'}
     monkeypatch.setattr('requests.get', get)
@@ -175,5 +175,4 @@ def test_listing_bubbles_client_error_up(monkeypatch):
     with pytest.raises(ClientError) as ex:
         s3_wrapper.list_bucket('bucket', 'prefix').files()
 
-    # raise IOError(str(ex))
     assert 'Access denied' == ex.value.response['Error']['Message']

--- a/zmon_worker_monitor/builtins/plugins/s3.py
+++ b/zmon_worker_monitor/builtins/plugins/s3.py
@@ -74,15 +74,19 @@ class S3Wrapper(object):
         finally:
             data.close()
 
-    def list_bucket(self, bucket_name, prefix, max_keys=100):
+    def list_bucket(self, bucket_name, prefix, max_items=100):
         """
-        List the objects in the bucket under the provided prefix.
+        List the objects in the bucket under the provided prefix.  Uses a paginator for cases when the number of objects
+        exceeds the hard limit of 1000.
         :param bucket_name: the name of the S3 Bucket
         :param prefix: the prefix to search under
-        :param max_keys: the maximum number of objects to list
+        :param max_items: the maximum number of objects to list
         :return: an S3FileList object
         """
-        response = self.__client.list_objects_v2(Bucket=bucket_name, Prefix=prefix, MaxKeys=max_keys)
+        paginator = self.__client.get_paginator('list_objects_v2')
+        response = paginator.paginate(Bucket=bucket_name, Prefix=prefix, PaginationConfig={'MaxItems': max_items}) \
+                            .build_full_result()
+
         return S3FileList(response)
 
 


### PR DESCRIPTION
list_objects_v2 is limited to 1000 items.  It's not that hard to reach this limit, so we need pagination.