### PR TITLE
Allow setting connect_timeout for Postgres.

### DIFF
--- a/tests/test_sql_postgresql.py
+++ b/tests/test_sql_postgresql.py
@@ -92,17 +92,19 @@ def fx_sql_error(request):
     return request.param
 
 
-def get_connection_str(shard_def, user='zmon', password='', timeout=60000, created_by=None, check_id=None, **kwargs):
+def get_connection_str(shard_def, user='zmon', password='', connect_timeout=5, timeout=60000,
+                       created_by=None, check_id=None, **kwargs):
     m = CONNECTION_RE.match(shard_def)
 
     connection_str = ("host='{host}' port='{port}' dbname='{dbname}' user='{user}' password='{password}' "
-                      "connect_timeout=5 options='-c statement_timeout={timeout}' "
+                      "connect_timeout='{connect_timeout}' options='-c statement_timeout={timeout}' "
                       "application_name='ZMON Check {check_id} (created by {created_by})' ").format(
         host=m.group('host'),
         port=int(m.group('port') or DEFAULT_PORT),
         dbname=m.group('dbname'),
         user=user,
         password=password,
+        connect_timeout=connect_timeout,
         timeout=timeout,
         check_id=check_id,
         created_by=make_safe(created_by),

--- a/zmon_worker_monitor/builtins/plugins/sql_postgresql.py
+++ b/zmon_worker_monitor/builtins/plugins/sql_postgresql.py
@@ -89,6 +89,7 @@ class SqlWrapper(object):
             shards,
             user='zmon',
             password='',
+            connect_timeout=5,
             timeout=60000,
             shard=None,
             created_by=None,
@@ -101,6 +102,8 @@ class SqlWrapper(object):
             A dict of shard definitions where key is the shard's name and value is the host/database string.
         user: str
         password: str
+        connect_timeout: int
+            Maximum wait for connection, in seconds.
         timeout: int
             Statement timeout in milliseconds.
         shard: str
@@ -126,13 +129,14 @@ class SqlWrapper(object):
             if not m:
                 raise CheckError('Invalid shard connection: {}'.format(shard_def))
             connection_str = ("host='{host}' port='{port}' dbname='{dbname}' user='{user}' password='{password}' "
-                              "connect_timeout=5 options='-c statement_timeout={timeout}' "
+                              "connect_timeout='{connect_timeout}' options='-c statement_timeout={timeout}' "
                               "application_name='ZMON Check {check_id} (created by {created_by})' ").format(
                 host=m.group('host'),
                 port=int(m.group('port') or DEFAULT_PORT),
                 dbname=m.group('dbname'),
                 user=user,
                 password=password,
+                connect_timeout=connect_timeout,
                 timeout=timeout,
                 check_id=check_id,
                 created_by=make_safe(created_by),


### PR DESCRIPTION
Pass connect_timeout from the check definition instead of hard-coding
it to 5s. #245 