### PR TITLE
add possibility to disable plugins from config 

### DIFF
--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -374,7 +374,6 @@ class TestPluginManager(unittest.TestCase):
         plugin_manager.collect_plugins(load_builtins=True, load_env=True, global_config=global_conf)
 
         disabled = [p.name for p in plugin_manager.get_all_plugins() if not p.is_activated]
-        self.assertTrue(len(disabled) == 1)
         self.assertIn('color_germany', disabled, 'color_germany is not disabled')
 
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -346,6 +346,37 @@ class TestPluginManager(unittest.TestCase):
 
         self.assertTrue(is_raised)
 
+    @patch.dict(os.environ, {'ZMON_PLUGINS': extras_plugin_dir_abs_path() + ':' + simple_plugin_dir_abs_path()})
+    def test_plugins_disable(self):
+        """
+        Test that a plugin can be disabled
+        """
+
+        # reload the plugin
+        reload(plugin_manager)
+
+        # Lets create a category filter that includes our builtin plugin type and 2 types we defines for our tests
+        category_filter = {
+            'Function': IFunctionFactoryPlugin,
+            'Color': IColorPlugin,
+            'Temperature': ITemperaturePlugin,
+        }
+
+        # inject as global conf to color_german plugin fashion sites different from the local conf
+        global_conf = {
+            'plugin.color_germany.enabled': False,
+            'plugin.color_germany.fashion_sites': 'superfashion.de hypefashion.de',
+        }
+
+        # init the plugin manager
+        plugin_manager.init_plugin_manager(category_filter=category_filter)
+
+        plugin_manager.collect_plugins(load_builtins=True, load_env=True, global_config=global_conf)
+
+        disabled = [p.name for p in plugin_manager.get_all_plugins() if not p.is_activated]
+        self.assertTrue(len(disabled) == 1)
+        self.assertIn('color_germany', disabled, 'color_germany is not disabled')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/zmon_worker_extras/check_plugins/saml.worker_plugin
+++ b/zmon_worker_extras/check_plugins/saml.worker_plugin
@@ -18,3 +18,4 @@ Description = Builtin plugin that provides a SAML request check function.
 ;; Note valueX will be overridden if Zmon's global config has:
 ;; plugin.{plugin_name}.{key} = valueY
 url = https://idp.example.com/profile/SAML2/Unsolicited/SSO?providerId=urn:self
+;; enabled = false

--- a/zmon_worker_monitor/adapters/disabled_plugin.py
+++ b/zmon_worker_monitor/adapters/disabled_plugin.py
@@ -29,4 +29,3 @@ class DisabledPlugin(object):
 
     def __getattr__(self, name):
         raise Exception('plugin {} is disabled, called: {}'.format(self._plugin_name, name))
-

--- a/zmon_worker_monitor/adapters/disabled_plugin.py
+++ b/zmon_worker_monitor/adapters/disabled_plugin.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+class DisabledPlugin(object):
+    _plugin_name = 'unknown'
+
+    def __init__(self, name):
+        """
+        Set the basic variables.
+        """
+        self.is_activated = False
+        self._plugin_name = name
+
+    def activate(self):
+        """
+        Called at plugin activation.
+        """
+        pass
+
+    def deactivate(self):
+        """
+        Called when the plugin is disabled.
+        """
+        self.is_activated = False
+
+    def configure(self, conf):
+        pass
+
+    def __getattr__(self, name):
+        raise Exception('plugin {} is disabled, called: {}'.format(self._plugin_name, name))
+

--- a/zmon_worker_monitor/main.py
+++ b/zmon_worker_monitor/main.py
@@ -113,7 +113,8 @@ def main(args=None):
 
     # load external plugins (should be run only once)
     plugin_manager.collect_plugins(global_config=config, load_builtins=True, load_env=True)
-    logger.info("Plugins loaded and active: {}".format([p.name for p in plugin_manager.get_all_plugins() if p.is_activated]))
+    active_plugins = [p.name for p in plugin_manager.get_all_plugins() if p.is_activated]
+    logger.info("Plugins loaded and active: {}".format(active_plugins))
 
     # start worker processes per queue according to the config
     queues = config['zmon.queues']

--- a/zmon_worker_monitor/main.py
+++ b/zmon_worker_monitor/main.py
@@ -113,6 +113,7 @@ def main(args=None):
 
     # load external plugins (should be run only once)
     plugin_manager.collect_plugins(global_config=config, load_builtins=True, load_env=True)
+    logger.info("Plugins loaded and active: {}".format([p.name for p in plugin_manager.get_all_plugins() if p.is_activated]))
 
     # start worker processes per queue according to the config
     queues = config['zmon.queues']

--- a/zmon_worker_monitor/plugin_manager.py
+++ b/zmon_worker_monitor/plugin_manager.py
@@ -213,6 +213,10 @@ def collect_plugins(load_builtins=True, load_env=True, additional_dirs=None, glo
                     str(c)[len(config_prefix):]: v for c, v in global_config.iteritems()
                     if str(c).startswith(config_prefix)
                 }
+                if config_prefix + 'enabled' in conf_global and not conf_global[config_prefix + 'enabled']:
+                    plugin.plugin_object.deactivate()
+                    logger.info('Plugin %s is disabled in config', plugin.name)
+                    continue
                 logger.debug('Plugin %s received global conf keys: %s', plugin.name, conf_global.keys())
             except Exception:
                 logger.exception('Failed to parse global configuration. Reason: ')


### PR DESCRIPTION
as given in the example of #71, this skips the plugin when `plugin.$NAME.enabled: False` is set

also allows to disable plugins with the `*.worker_plugin` config to set `enabled: false` in the `[Configuration]` section

addresses #71 