### PR TITLE
align scalyr buckets

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/scalyr.py
+++ b/zmon_worker_monitor/builtins/plugins/scalyr.py
@@ -86,10 +86,9 @@ class ScalyrWrapper(object):
         endTime = None
         if align != 0:
             cur_time = int(time.time())  # this assumes the worker is running with UTC time
-            end = cur_time - (cur_time % align)
-            start = end - (minutes * 60)
-            startTime = start
-            endTime = end
+            endTime = cur_time - (cur_time % align)
+            startTime = endTime - (minutes * 60)
+
         val = {
             'token': self.read_key,
             'queries': [

--- a/zmon_worker_monitor/builtins/plugins/scalyr.py
+++ b/zmon_worker_monitor/builtins/plugins/scalyr.py
@@ -3,6 +3,7 @@
 
 import requests
 import logging
+import time
 
 from zmon_worker_monitor.zmon_worker.errors import ConfigurationError
 from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
@@ -36,8 +37,8 @@ class ScalyrWrapper(object):
             raise ConfigurationError('Scalyr read key is not set.')
         self.read_key = read_key
 
-    def count(self, query, minutes=5):
-        return self.timeseries(query, function='count', minutes=minutes, buckets=1, prio='low')
+    def count(self, query, minutes=5, align=0):
+        return self.timeseries(query, function='count', minutes=minutes, buckets=1, prio='low', align=align)
 
     def function(self, function, query, minutes=5):
 
@@ -80,20 +81,29 @@ class ScalyrWrapper(object):
         j = r.json()
         return j
 
-    def timeseries(self, filter, function='count', minutes=30, buckets=1, prio='low'):
-
+    def timeseries(self, filter, function='count', minutes=30, buckets=1, prio='low', align=0):
+        startTime = str(minutes) + 'm'
+        endTime = None
+        if align != 0:
+            cur_time = int(time.time())  # this assumes the worker is running with UTC time
+            end = cur_time - (cur_time % align)
+            start = end - (minutes * 60)
+            startTime = start
+            endTime = end
         val = {
             'token': self.read_key,
             'queries': [
                 {
                     'filter': filter,
                     'function': function,
-                    'startTime': str(minutes) + 'm',
+                    'startTime': startTime,
                     'buckets': buckets,
                     'priority': prio
                 }
             ]
         }
+        if endTime:
+            val['queries'][0]['endTime'] = endTime
 
         r = requests.post(self.__timeseries_url, json=val, headers={'Content-Type': 'application/json'})
 


### PR DESCRIPTION
"timeseriesQuery works by precomputing a timeseries using 30-second buckets. For example, if you query for instances of the word "error", then internally Scalyr will maintain a count of the number of times "error" appears from 00:00:00 to 00:00:30, from 00:00:30 to 00:01:00, etc."