### PR TITLE
use ISO timestamps in process title

### DIFF
--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -123,8 +123,9 @@ normalize_kairos_id = propartial(KAIROS_ID_FORBIDDEN_RE.sub, '_')
 
 
 def setp(check_id, entity, msg):
-    setproctitle.setproctitle('zmon-worker check {} on {} {} {}'.format(check_id, entity, msg,
-                                                                        datetime.now().strftime('%H:%M:%S.%f')))
+    setproctitle.setproctitle(
+        'zmon-worker check {} on {} {} {}'.format(check_id, entity, msg,
+                                                  datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%f')))
 
 
 def get_kairosdb_value(name, points, tags):

--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -124,8 +124,7 @@ normalize_kairos_id = propartial(KAIROS_ID_FORBIDDEN_RE.sub, '_')
 
 def setp(check_id, entity, msg):
     setproctitle.setproctitle(
-        'zmon-worker check {} on {} {} {}'.format(check_id, entity, msg,
-                                                  datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%f')))
+        'zmon-worker check {} on {} {} {}'.format(check_id, entity, msg, datetime.now().isoformat()))
 
 
 def get_kairosdb_value(name, points, tags):


### PR DESCRIPTION
for easier parsing and with date instead of just hours/minutes