### PR TITLE
Flexible start and end time

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/scalyr.py
+++ b/zmon_worker_monitor/builtins/plugins/scalyr.py
@@ -39,14 +39,15 @@ class ScalyrWrapper(object):
     def count(self, query, minutes=5):
         return self.timeseries(query, function='count', minutes=minutes, buckets=1, prio='low')
 
-    def function(self, function, query, minutes=5):
+    def function(self, function, query, start_time='5m', end_time=None):
 
         val = {
             'token': self.read_key,
             'queryType': 'numeric',
             'filter': query,
             'function': function,
-            'startTime': str(minutes) + 'm',
+            'startTime': start_time,
+            'endTime': end_time,
             'priority': 'low',
             'buckets': 1
         }


### PR DESCRIPTION
This PR makes the start and end time for a function query flexible
using parameters.

It's required for Scalyr queries like this (example uses the [Scalyr tool](https://github.com/scalyr/scalyr-tool)):
    
    scalyr numeric-query "tag='logVolume' metric='logBytes'" --function='sumPerSecond(value)' --start "Aug 20" --end "+30d" --buckets 1