### PR TITLE
Include description in opsgenie notification

### DIFF
--- a/tests/test_opsgenie_notification.py
+++ b/tests/test_opsgenie_notification.py
@@ -25,15 +25,27 @@ HEADERS = {
 }
 
 
-@pytest.mark.parametrize('is_alert,priority', ((True, None), (True, 'P4'), (False, None)))
-def test_opsgenie_notification(monkeypatch, is_alert, priority):
+@pytest.mark.parametrize('is_alert,priority,override_description',
+                         ((True, None, None),
+                          (True, 'P4', None),
+                          (False, None, None),
+                          (True, None, "override description"))
+                         )
+def test_opsgenie_notification(monkeypatch, is_alert, priority, override_description):
     post = MagicMock()
 
     monkeypatch.setattr('requests.post', post)
 
     alert = {
         'alert_changed': True, 'changed': True, 'is_alert': is_alert, 'entity': {'id': 'e-1'}, 'worker': 'worker-1',
-        'alert_def': {'name': 'Alert', 'team': 'zmon', 'responsible_team': 'zmon', 'id': 123, 'priority': 1}
+        'alert_def': {
+            'name': 'Alert',
+            'team': 'zmon',
+            'description': 'zmon description',
+            'responsible_team': 'zmon',
+            'id': 123,
+            'priority': 1
+        }
     }
 
     NotifyOpsgenie._config = {'notifications.opsgenie.apikey': API_KEY}
@@ -44,7 +56,23 @@ def test_opsgenie_notification(monkeypatch, is_alert, priority):
     else:
         priority = 'P1'
 
-    r = NotifyOpsgenie.notify(alert, message=MESSAGE, include_alert=False, teams=['team-1', 'team-2'], **kwargs)
+    if override_description:
+        r = NotifyOpsgenie.notify(
+            alert,
+            message=MESSAGE,
+            include_alert=False,
+            teams=['team-1', 'team-2'],
+            description=override_description,
+            **kwargs
+        )
+    else:
+        r = NotifyOpsgenie.notify(
+            alert,
+            message=MESSAGE,
+            include_alert=False,
+            teams=['team-1', 'team-2'],
+            **kwargs
+        )
 
     params = {}
 
@@ -52,6 +80,7 @@ def test_opsgenie_notification(monkeypatch, is_alert, priority):
         data = {
             'alias': 'ZMON-123',
             'message': '[zmon] - {}'.format(MESSAGE),
+            'description': 'zmon description',
             'entity': 'e-1',
             'priority': priority,
             'tags': [],
@@ -59,6 +88,10 @@ def test_opsgenie_notification(monkeypatch, is_alert, priority):
             'source': 'worker-1',
             'note': '',
         }
+
+        if override_description:
+            data['description'] = override_description
+
     else:
         data = {
             'user': 'ZMON',
@@ -84,7 +117,13 @@ def test_opsgenie_notification_per_entity(monkeypatch):
     alert = {
         'changed': True, 'is_alert': True, 'entity': {'id': 'e-1'}, 'worker': 'worker-1', 'time': datetime.now(),
         'alert_def': {
-            'name': 'Alert', 'team': 'team-1', 'responsible_team': 'zmon', 'id': 123, 'priority': 3, 'tags': ['tag-1']
+            'name': 'Alert',
+            'team': 'team-1',
+            'description': 'some description',
+            'responsible_team': 'zmon',
+            'id': 123,
+            'priority': 3,
+            'tags': ['tag-1']
         },
     }
 
@@ -98,6 +137,7 @@ def test_opsgenie_notification_per_entity(monkeypatch):
     data = {
         'alias': 'ZMON-123-e-1',
         'message': '[zmon] - {}'.format(MESSAGE),
+        'description': 'some description',
         'source': 'worker-1',
         'note': 'https://zmon.example.org/#/alert-details/123',
         'entity': 'e-1',

--- a/tests/test_opsgenie_notification.py
+++ b/tests/test_opsgenie_notification.py
@@ -41,7 +41,6 @@ def test_opsgenie_notification(monkeypatch, is_alert, priority, override_descrip
         'alert_def': {
             'name': 'Alert',
             'team': 'zmon',
-            'description': 'zmon description',
             'responsible_team': 'zmon',
             'id': 123,
             'priority': 1
@@ -80,7 +79,7 @@ def test_opsgenie_notification(monkeypatch, is_alert, priority, override_descrip
         data = {
             'alias': 'ZMON-123',
             'message': '[zmon] - {}'.format(MESSAGE),
-            'description': 'zmon description',
+            'description': '',
             'entity': 'e-1',
             'priority': priority,
             'tags': [],
@@ -119,7 +118,6 @@ def test_opsgenie_notification_per_entity(monkeypatch):
         'alert_def': {
             'name': 'Alert',
             'team': 'team-1',
-            'description': 'some description',
             'responsible_team': 'zmon',
             'id': 123,
             'priority': 3,
@@ -137,7 +135,7 @@ def test_opsgenie_notification_per_entity(monkeypatch):
     data = {
         'alias': 'ZMON-123-e-1',
         'message': '[zmon] - {}'.format(MESSAGE),
-        'description': 'some description',
+        'description': '',
         'source': 'worker-1',
         'note': 'https://zmon.example.org/#/alert-details/123',
         'entity': 'e-1',

--- a/zmon_worker_monitor/zmon_worker/notifications/opsgenie.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/opsgenie.py
@@ -70,7 +70,6 @@ class NotifyOpsgenie(BaseNotification):
 
         responsible_team = alert['alert_def'].get('responsible_team', teams[0]['name'])
         msg = message if message else cls._get_subject(alert, include_event=False)
-        desc = description if description else alert['alert_def'].get('description', None)
 
         details = {
             'worker': alert['worker'],
@@ -90,7 +89,7 @@ class NotifyOpsgenie(BaseNotification):
                 'teams': teams,
                 'message': '[{}] - {}'.format(responsible_team, msg),  # TODO: remove when it is no longer needed!
                 'source': alert.get('worker', ''),
-                'description': desc,
+                'description': description,
                 'entity': entity['id'],
                 'note': note,
                 'priority': priority,

--- a/zmon_worker_monitor/zmon_worker/notifications/opsgenie.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/opsgenie.py
@@ -21,7 +21,16 @@ logger = logging.getLogger(__name__)
 
 class NotifyOpsgenie(BaseNotification):
     @classmethod
-    def notify(cls, alert, teams=None, per_entity=False, include_alert=True, priority=None, message='', **kwargs):
+    def notify(cls,
+               alert,
+               teams=None,
+               per_entity=False,
+               include_alert=True,
+               priority=None,
+               message='',
+               description='',
+               **kwargs):
+
         url = 'https://api.opsgenie.com/v2/alerts'
 
         repeat = kwargs.get('repeat', 0)
@@ -61,6 +70,7 @@ class NotifyOpsgenie(BaseNotification):
 
         responsible_team = alert['alert_def'].get('responsible_team', teams[0]['name'])
         msg = message if message else cls._get_subject(alert, include_event=False)
+        desc = description if description else alert['alert_def'].get('description', None)
 
         details = {
             'worker': alert['worker'],
@@ -80,6 +90,7 @@ class NotifyOpsgenie(BaseNotification):
                 'teams': teams,
                 'message': '[{}] - {}'.format(responsible_team, msg),  # TODO: remove when it is no longer needed!
                 'source': alert.get('worker', ''),
+                'description': desc,
                 'entity': entity['id'],
                 'note': note,
                 'priority': priority,


### PR DESCRIPTION
This Pr adds description text to the opsgenie alert.  The default description is taken from the zmon description field. Alternatively a description can be provided to override the default.

addresses https://github.com/zalando-zmon/zmon-worker/issues/278