### PR TITLE
add basic auth settings

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -388,3 +388,9 @@ def test_basicauth_conf(monkeypatch):
     fact = HttpFactory()
     fact.configure({'http.basic_auth': 'user:pass'})
     assert fact._basic_auth_users == {'user': 'pass'}
+
+
+def test_extra_headers(monkeypatch):
+    fact = HttpFactory()
+    fact.configure({'http.extra_headers': '{"foo": {"X-MyFoo": "bar"}}'})
+    assert fact._extra_headers == {'foo': {'X-MyFoo': 'bar'}}

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -2,7 +2,7 @@ import requests
 
 import pytest
 from mock import MagicMock
-from zmon_worker_monitor.builtins.plugins.http import HttpWrapper
+from zmon_worker_monitor.builtins.plugins.http import HttpWrapper, HttpFactory
 from zmon_worker_monitor.zmon_worker.errors import HttpError, CheckError, ConfigurationError
 from zmon_worker_monitor.zmon_worker.common.http import get_user_agent
 
@@ -382,3 +382,9 @@ def test_http_certs(monkeypatch, url, port, err):
         ssl_sock.connect.assert_called_with(('zmon', port))
 
         ssl_sock.close.assert_called()
+
+
+def test_basicauth_conf(monkeypatch):
+    fact = HttpFactory()
+    fact.configure({'http.basic_auth': 'user:pass'})
+    assert fact._basic_auth_users == {'user': 'pass'}


### PR DESCRIPTION
users can set env var or config to use `http(user="name").code()` to fetch the
password on the fly from plugin.http.basic_auth