### PR TITLE
move connect() to __init__ for cassandra wrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.4.3
 bs4
-cassandra-driver==3.6.0
+cassandra-driver==3.12.0
 dnspython
 dogpile.cache
 eventlog-writer==0.4.5

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -46,6 +46,8 @@ def test_cassandra_execute(monkeypatch, kwargs):
     cluster.assert_called_with([node], connect_timeout=cassandra.connect_timeout, auth_provider=auth_provider,
                                port=port, protocol_version=protocol_version)
 
+    cassandra = None
+
     client.connect.assert_called_once()
     client.shutdown.assert_called_once()
 
@@ -68,9 +70,8 @@ def test_cassandra_execute_exception(monkeypatch):
 
     monkeypatch.setattr('zmon_worker_monitor.builtins.plugins.cassandra_wrapper.Cluster', cluster)
 
-    cassandra = CassandraWrapper(node, keyspace)
-
     with pytest.raises(RuntimeError):
+        cassandra = CassandraWrapper(node, keyspace)
         res = cassandra.execute('SELECT')
 
         assert res == result

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -55,7 +55,7 @@ def test_cassandra_execute(monkeypatch, kwargs):
     session.execute.assert_called_with(stmt)
 
 
-def test_cassandra_execute_exception(monkeypatch):
+def test_cassandra_connect_exception(monkeypatch):
     node = 'cassandra-node'
     keyspace = 'users'
 
@@ -78,3 +78,31 @@ def test_cassandra_execute_exception(monkeypatch):
 
         client.connect.assert_called_once()
         client.shutdown.assert_called_once()
+
+
+def test_cassandra_execute_exception(monkeypatch):
+    node = 'cassandra-node'
+    keyspace = 'users'
+
+    result = []
+
+    client = MagicMock()
+    cluster = MagicMock()
+    session = MagicMock()
+
+    cluster.return_value = client
+
+    client.connect.return_value = session
+
+    session.execute.side_effect = RuntimeError
+
+    monkeypatch.setattr('zmon_worker_monitor.builtins.plugins.cassandra_wrapper.Cluster', cluster)
+    cassandra = CassandraWrapper(node, keyspace)
+
+    with pytest.raises(RuntimeError):
+        res = cassandra.execute('SELECT')
+
+        assert res == result
+
+        client.connect.assert_called_once()
+        client.shutdown.assert_not_called()

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -94,10 +94,12 @@ def test_cassandra_execute_exception(monkeypatch):
     session.execute.side_effect = RuntimeError
 
     monkeypatch.setattr('zmon_worker_monitor.builtins.plugins.cassandra_wrapper.Cluster', cluster)
-    cassandra = CassandraWrapper(node, keyspace)
 
     with pytest.raises(RuntimeError):
-        cassandra.execute('SELECT')
+        def f():
+            cassandra = CassandraWrapper(node, keyspace)
+            cassandra.execute('SELECT')
+        f()
 
     session.execute.assert_called_with('SELECT')
     client.connect.assert_called_once()

--- a/tests/test_cassandra.py
+++ b/tests/test_cassandra.py
@@ -101,4 +101,4 @@ def test_cassandra_execute_exception(monkeypatch):
 
     session.execute.assert_called_with('SELECT')
     client.connect.assert_called_once()
-    client.shutdown.assert_not_called()
+    client.shutdown.assert_called_once()

--- a/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
@@ -70,9 +70,12 @@ class CassandraWrapper(object):
             self._cluster.shutdown()
 
     def execute(self, stmt):
-        rs = self._session.execute(stmt)
-
         result = []
+        try:
+            rs = self._session.execute(stmt)
+        except Exception:
+            self._cluster.shutdown()
+            raise
 
         for r in rs:
             result.append(r)

--- a/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
@@ -70,18 +70,11 @@ class CassandraWrapper(object):
             self._cluster.shutdown()
 
     def execute(self, stmt):
-        try:
-            rs = self._session.execute(stmt)
+        rs = self._session.execute(stmt)
 
-            result = []
+        result = []
 
-            for r in rs:
-                result.append(r)
+        for r in rs:
+            result.append(r)
 
-            return result
-
-        except Exception:
-            self._cluster.shutdown()
-            self._cluster = None
-
-        return {}
+        return result

--- a/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
@@ -54,7 +54,6 @@ class CassandraWrapper(object):
         self.connect_timeout = connect_timeout
         self.protocol_version = protocol_version
 
-    def execute(self, stmt):
         auth_provider = None
         if self.__username and self.__password:
             auth_provider = PlainTextAuthProvider(username=self.__username, password=self.__password)
@@ -62,12 +61,17 @@ class CassandraWrapper(object):
         cl = Cluster(self.seeds, connect_timeout=self.connect_timeout, auth_provider=auth_provider,
                      protocol_version=self.protocol_version, port=self.port)
 
-        session = None
-        try:
-            session = cl.connect()
-            session.set_keyspace(self.keyspace)
+        self._session = cl.connect()
+        self._cluster = cl
+        self._session.set_keyspace(self.keyspace)
 
-            rs = session.execute(stmt)
+    def __del__(self):
+        if self._cluster:
+            self._cluster.shutdown()
+
+    def execute(self, stmt):
+        try:
+            rs = self._session.execute(stmt)
 
             result = []
 
@@ -76,7 +80,8 @@ class CassandraWrapper(object):
 
             return result
 
-        finally:
-            cl.shutdown()
+        except Exception:
+            self._cluster.shutdown()
+            self._cluster = None
 
         return {}

--- a/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/cassandra_wrapper.py
@@ -71,11 +71,7 @@ class CassandraWrapper(object):
 
     def execute(self, stmt):
         result = []
-        try:
-            rs = self._session.execute(stmt)
-        except Exception:
-            self._cluster.shutdown()
-            raise
+        rs = self._session.execute(stmt)
 
         for r in rs:
             result.append(r)


### PR DESCRIPTION
fixes #306

shutdown() now called on destruction, not after each execute()