### PR TITLE
add exception class and line number

### DIFF
--- a/tests/test_main_task.py
+++ b/tests/test_main_task.py
@@ -183,7 +183,7 @@ def test_evaluate_alert(monkeypatch):
     # produce exception
     alert_def['condition'] = 'value["missing-key"] > 0'
     is_alert, captures = task.evaluate_alert(alert_def, req, result)
-    assert {'p1': 'x', 'exception': "'int' object has no attribute '__getitem__'"} == captures
+    assert {'p1': 'x', 'exception': "TypeError line 1: 'int' object has no attribute '__getitem__'"} == captures
     assert is_alert
 
 

--- a/tests/test_main_task.py
+++ b/tests/test_main_task.py
@@ -183,7 +183,8 @@ def test_evaluate_alert(monkeypatch):
     # produce exception
     alert_def['condition'] = 'value["missing-key"] > 0'
     is_alert, captures = task.evaluate_alert(alert_def, req, result)
-    assert {'p1': 'x', 'exception': "TypeError line 1: 'int' object has no attribute '__getitem__'"} == captures
+    assert 'p1' in captures and captures.get('p1') == 'x'
+    assert 'exception' in captures and "'int' object has no attribute '__getitem__'" in captures.get('exception')
     assert is_alert
 
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -81,7 +81,7 @@ def execute_check(tmpdir, monkeypatch, check_command, expected_strings):
 
 def test_check_failure(tmpdir, monkeypatch):
     execute_check(tmpdir, monkeypatch, 'invalid_python_code',
-                  ['"value": "name \'invalid_python_code\' is not defined"', '"exc": 1'])
+                  ['"value": "NameError line 1: name \'invalid_python_code\' is not defined"', '"exc": 1'])
 
 
 def test_check_success(tmpdir, monkeypatch):

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -81,7 +81,7 @@ def execute_check(tmpdir, monkeypatch, check_command, expected_strings):
 
 def test_check_failure(tmpdir, monkeypatch):
     execute_check(tmpdir, monkeypatch, 'invalid_python_code',
-                  ['"value": "NameError line 1: name \'invalid_python_code\' is not defined"', '"exc": 1'])
+                  ['"value": "Traceback (most recent', 'name \'invalid_python_code\' is not defined', '"exc": 1'])
 
 
 def test_check_success(tmpdir, monkeypatch):

--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -580,12 +580,6 @@ def evaluate_condition(val, condition, **ctx):
     return safe_eval(_prepare_condition(condition), eval_source='<alert-condition>', value=val, **ctx)
 
 
-def exception_line_number(e):
-    _, _, tb = sys.exc_info()
-    ex = traceback.extract_tb(tb)
-    return "{} line {}: {}".format(e.__class__.__name__, ex[-1][1], e)
-
-
 class MalformedCheckResult(Exception):
     def __init__(self, msg):
         Exception.__init__(self, msg)
@@ -1211,7 +1205,7 @@ class MainTask(object):
         except (SecurityError, InsufficientPermissionsError), e:
             raise(e)
         except Exception, e:
-            raise Exception(exception_line_number(e))
+            raise Exception(traceback.format_exc())
 
     def _get_check_result(self, req):
         r = self._get_check_result_internal(req)
@@ -1390,7 +1384,7 @@ class MainTask(object):
                                                                                    captures,
                                                                                    alert_parameters))
         except Exception, e:
-            captures['exception'] = exception_line_number(e)
+            captures['exception'] = traceback.format_exc()
             result = True
 
         try:


### PR DESCRIPTION
to exceptions for checks and alerts. This way we get a better message
for the users, e.g. a

    KeyError line 4: 'foo'

instead of just

    'foo'