### PR TITLE
Implements Batch Query in KairosDB wrapper

### DIFF
--- a/tests/test_kairosdb.py
+++ b/tests/test_kairosdb.py
@@ -27,7 +27,12 @@ URL = 'http://kairosdb'
         {'queries': [{'results': [1, 2, 3, 4, 5, 6, 7, 8]}]},
     ),
     (
-        {'name': 'check1-metric', 'aggregators': [{'name': 'sum'}], 'start_absolute': 1498049043491, 'end_absolute': 0},
+        {
+            'name': 'check1-metric',
+            'aggregators': [{'name': 'sum'}],
+            'start_absolute': 1498049043491,
+            'end_absolute': 0
+        },
         {'queries': [{'results': [1, 2, 3, 4, 5, 6, 7, 8]}]}
     ),
     (

--- a/tests/test_kairosdb.py
+++ b/tests/test_kairosdb.py
@@ -226,7 +226,7 @@ def get_query_batch(kwargs):
     start = kwargs.get('start', 5)
     time_unit = kwargs.get('time_unit', 'minutes')
 
-    q = {'metrics': []}
+    q = {'metrics': kwargs['metrics']}
 
     if 'start_absolute' in kwargs:
         q['start_absolute'] = kwargs['start_absolute']
@@ -244,8 +244,6 @@ def get_query_batch(kwargs):
                 'value': kwargs['end'],
                 'unit': time_unit
             }
-
-    q['metrics'] = kwargs['metrics']
 
     return q
 

--- a/tests/test_kairosdb.py
+++ b/tests/test_kairosdb.py
@@ -56,7 +56,7 @@ def fx_query(request):
                 {'name': 'check2-metric'}
             ]
         },
-        {'queries': [{'results': [1, 2]}]},
+        {'queries': [{'results': [1, 2]}, {'results': [2, 3]}]},
     ),
     (
         {
@@ -71,7 +71,7 @@ def fx_query(request):
                 },
             ]
         },
-        {'queries': [{'results': [1, 2, 3]}]},
+        {'queries': [{'results': [1, 2, 3]}, {'results': [2, 3]}]},
     ),
     (
         {
@@ -88,7 +88,7 @@ def fx_query(request):
                 },
             ],
         },
-        {'queries': [{'results': [1, 2, 3, 4]}]},
+        {'queries': [{'results': [1, 2, 3, 4]}, {'results': [4, 3, 2, 1]}]},
     ),
     (
         {
@@ -106,7 +106,7 @@ def fx_query(request):
             'end': 1,
             'time_unit': 'hours'
         },
-        {'queries': [{'results': [1, 2, 3, 4, 5, 6, 7, 8]}]},
+        {'queries': [{'results': [1, 2, 3, 4, 5, 6]}, {'results': [6, 5, 4, 3, 2, 1]}]},
     ),
     (
         {
@@ -123,7 +123,7 @@ def fx_query(request):
             'start_absolute': 1498049043491,
             'end_absolute': 0
         },
-        {'queries': [{'results': [1, 2, 3, 4, 5, 6, 7, 8]}]}
+        {'queries': [{'results': [1, 2, 3, 4, 5]}, {'results': [5, 4, 3, 2, 1]}]},
     ),
     (
         {
@@ -291,7 +291,7 @@ def test_kairosdb_query_batch(monkeypatch, fx_query_batch):
             cli.query_batch(**kwargs)
     else:
         result = cli.query_batch(**kwargs)
-        assert result == res['queries'][0]
+        assert result == res['queries']
 
     post.assert_called_with(get_final_url(), json=q)
 

--- a/zmon_worker_monitor/builtins/plugins/kairosdb.py
+++ b/zmon_worker_monitor/builtins/plugins/kairosdb.py
@@ -120,7 +120,7 @@ class KairosdbWrapper(object):
         if tags:
             metric['tags'] = tags
 
-        return self.query_batch([metric], start, end, time_unit, start_absolute, end_absolute)
+        return self.query_batch([metric], start, end, time_unit, start_absolute, end_absolute)[0]
 
     def tagnames(self):
         return []
@@ -170,8 +170,8 @@ class KairosdbWrapper(object):
         :param end_absolute: Absolute end time in milliseconds, overrides the end parameter which is relative
         :type end_absolute: long
 
-        :return: Result queries.
-        :rtype: dict
+        :return: Array of results for each queried metric
+        :rtype: list
         """
         url = os.path.join(self.url, DATAPOINTS_ENDPOINT)
 
@@ -200,7 +200,7 @@ class KairosdbWrapper(object):
         try:
             response = self.__session.post(url, json=q)
             if response.ok:
-                return response.json()['queries'][0]
+                return response.json()['queries']
             else:
                 raise Exception(
                     'KairosDB Query failed: {} with status {}:{}'.format(q, response.status_code, response.text))

--- a/zmon_worker_monitor/builtins/plugins/kairosdb.py
+++ b/zmon_worker_monitor/builtins/plugins/kairosdb.py
@@ -152,8 +152,8 @@ class KairosdbWrapper(object):
                                             # all the records with given tag and given values
                 }
             }
-        }
-        :type queries: dict
+        ]
+        :type metrics: dict
 
         :param start: Relative start time. Default is 5.
         :type start: int


### PR DESCRIPTION
This method allows sending a single request to Kairos that fetches data for multiple metric names.