### PR TITLE
Make recursive S3 listing optional

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -131,11 +131,40 @@ def test_listing_on_existing_prefix(monkeypatch):
 
     file_list = s3_wrapper.list_bucket('bucket', 'prefix')
 
+    client.get_paginator.return_value.paginate.assert_called_with(
+        Bucket='bucket',
+        Prefix='prefix',
+        PaginationConfig={'MaxItems': 100}
+    )
+
     assert file_list is not None
     assert len(file_list.files()) is 1
     assert file_list.files()[0]['file_name'] is 'some_file'
     assert file_list.files()[0]['size'] is 123
     assert file_list.files()[0]['last_modified'] == datetime(2015, 1, 15, 14, 34, 56)
+
+
+def test_listing_with_delimiter(monkeypatch):
+
+    client = MagicMock()
+
+    def writer_side_effect(*args, **kwargs):
+        return {}
+    client.get_paginator.return_value.paginate.return_value.build_full_result.side_effect = writer_side_effect
+    get = MagicMock()
+    get.return_value.json.return_value = {'region': 'eu-central-1'}
+    monkeypatch.setattr('requests.get', get)
+    monkeypatch.setattr('boto3.client', lambda x, region_name: client)
+    s3_wrapper = S3Wrapper()
+
+    file_list = s3_wrapper.list_bucket('bucket', 'prefix', recursive=False)
+
+    client.get_paginator.return_value.paginate.assert_called_with(
+        Bucket='bucket',
+        Prefix='prefix',
+        Delimiter='/',
+        PaginationConfig={'MaxItems': 100}
+    )
 
 
 def test_listing_on_prefix_that_has_no_objects(monkeypatch):

--- a/zmon_worker_monitor/builtins/plugins/s3.py
+++ b/zmon_worker_monitor/builtins/plugins/s3.py
@@ -69,18 +69,21 @@ class S3Wrapper(object):
         finally:
             data.close()
 
-    def list_bucket(self, bucket_name, prefix, max_items=100):
+    def list_bucket(self, bucket_name, prefix, recursive=True, max_items=100):
         """
         List the objects in the bucket under the provided prefix.  Uses a paginator for cases when the number of objects
         exceeds the hard limit of 1000.
         :param bucket_name: the name of the S3 Bucket
         :param prefix: the prefix to search under
+        :param recursive: defines if the listing should contain deeply nested keys
         :param max_items: the maximum number of objects to list
         :return: an S3FileList object
         """
         paginator = self.__client.get_paginator('list_objects_v2')
-        response = paginator.paginate(Bucket=bucket_name, Prefix=prefix, PaginationConfig={'MaxItems': max_items}) \
-                            .build_full_result()
+        params = dict(Bucket=bucket_name, Prefix=prefix, PaginationConfig={'MaxItems': max_items})
+        if not recursive:
+            params['Delimiter'] = '/'
+        response = paginator.paginate(**params).build_full_result()
 
         return S3FileList(response)
 


### PR DESCRIPTION
For non-recursive listing use Delimiter='/' the same way `aws s3 ls' command
works.  The default is still recursive, to support existing use cases.