### PR TITLE
fix UnicodeEncodeError in subject

### DIFF
--- a/zmon_worker_monitor/zmon_worker/notifications/notification.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/notification.py
@@ -53,6 +53,7 @@ class BaseNotification(object):
     @classmethod
     def _get_expanded_alert_name(cls, alert, custom_message=None):
         name = (alert['alert_def']['name'] if not custom_message else custom_message)
+        name = name.encode('utf8')
         try:
             replacements = {'entities': alert['entity']['id']}
             replacements.update(alert['captures'])


### PR DESCRIPTION
```
File "/usr/local/lib/python2.7/dist-packages/zmon_worker-0.1-py2.7.egg/zmon_worker_monitor/zmon_worker/notifications/mail.py",
 line 63, in notify
     subject = cls._get_subject(alert, custom_message=kwargs.get('subject'))
File "/usr/local/lib/python2.7/dist-packages/zmon_worker-0.1-py2.7.egg/zmon_worker_monitor/zmon_worker/notifications/notification.py",
 line 49, in _get_subject
     return '{}{} on {}'.format(prefix, name, alert['entity']['id'])
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in
position 8: ordinal not in range(128)
```