### PR TITLE
Fix arg order in s3

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/s3.py
+++ b/zmon_worker_monitor/builtins/plugins/s3.py
@@ -69,14 +69,14 @@ class S3Wrapper(object):
         finally:
             data.close()
 
-    def list_bucket(self, bucket_name, prefix, recursive=True, max_items=100):
+    def list_bucket(self, bucket_name, prefix, max_items=100, recursive=True):
         """
         List the objects in the bucket under the provided prefix.  Uses a paginator for cases when the number of objects
         exceeds the hard limit of 1000.
         :param bucket_name: the name of the S3 Bucket
         :param prefix: the prefix to search under
-        :param recursive: defines if the listing should contain deeply nested keys
         :param max_items: the maximum number of objects to list
+        :param recursive: defines if the listing should contain deeply nested keys
         :return: an S3FileList object
         """
         paginator = self.__client.get_paginator('list_objects_v2')


### PR DESCRIPTION
Fix args order in s3 wrapper to avoid breaking alerts with positional args