### PR TITLE
extended option for hipchat notifications

### DIFF
--- a/zmon_worker_monitor/zmon_worker/notifications/hipchat.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/hipchat.py
@@ -25,6 +25,7 @@ class NotifyHipchat(BaseNotification):
         repeat = kwargs.get('repeat', 0)
         notify = kwargs.get('notify', False)
         alert_def = alert['alert_def']
+        message_format = kwargs.get('message_format', 'html')
 
         current_span.set_tag('alert_id', alert_def['id'])
 
@@ -47,12 +48,16 @@ class NotifyHipchat(BaseNotification):
             alert_id = alert['alert_def']['id']
             alert_url = urlparse.urljoin(zmon_host, '/#/alert-details/{}'.format(alert_id)) if zmon_host else ''
             link_text = kwargs.get('link_text', 'go to alert')
-            message_text += ' -- <a href="{}" target="_blank">{}</a>'.format(alert_url, link_text)
+            if message_format == 'html':
+                message_text += ' -- <a href="{}" target="_blank">{}</a>'.format(alert_url, link_text)
+            else:
+                message_text += ' -- {} - {}'.format(link_text, alert_url)
 
         message = {
             'message': message_text,
             'color': color,
-            'notify': notify
+            'notify': notify,
+            'message_format': message_format
         }
 
         try:


### PR DESCRIPTION
introduce option message_format - html (default as before) or text (will allow to send @mentions)