### PR TITLE
Add fields for monitoring replication

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
@@ -13,6 +13,9 @@ STATISTIC_GAUGE_KEYS = frozenset([
     'connected_clients',
     'connected_slaves',
     'instantaneous_ops_per_sec',
+    'master_repl_offset',
+    'role',
+    'slave0',
     'used_memory',
     'used_memory_rss',
 ])


### PR DESCRIPTION
Add `master_repl_offset`, `role` and `slave0` fields, which will allow us to create a ZMON check to alert us when replication is broken.