### PR TITLE
Add endTime support for Scalyr Wrapper

### DIFF
--- a/tests/test_scalyr.py
+++ b/tests/test_scalyr.py
@@ -273,14 +273,16 @@ def fx_timeseries_aligned(request):
 
 
 def get_query(query_type, func, key, **kwargs):
+    if 'end' not in kwargs:
+        kwargs['end'] = 0
     start_time = str(kwargs.get('minutes', '5')) + 'm'
     end_time = None
     if kwargs.get('align', 0) != 0:
         cur_time = int(time.time())
         end_time = cur_time - (cur_time % kwargs.get('align'))
         start_time = end_time - (kwargs.get('minutes', 5) * 60)
-    elif kwargs.get('until', None) is not None:
-        end_time = str(kwargs.get('until')) + 'm'
+    elif kwargs.get('end', None) is not None:
+        end_time = str(kwargs.get('end')) + 'm'
 
     q = {
         'token': key,
@@ -531,9 +533,9 @@ def test_scalyr_http_error(monkeypatch, method):
 
 
 @pytest.mark.parametrize(
-        'until', [(2880, None), (2880, 0), (2880, 1440), (1439, 0)])
-def test_scalyr_timeseries_until(monkeypatch, until):
-    start, end = until
+        'begin_and_end', [(2880, None), (2880, 0), (2880, 1440), (1439, 0)])
+def test_scalyr_timeseries_end(monkeypatch, begin_and_end):
+    start, end = begin_and_end
 
     read_key = '123'
 
@@ -543,9 +545,9 @@ def test_scalyr_timeseries_until(monkeypatch, until):
     monkeypatch.setattr('requests.post', post)
 
     scalyr = ScalyrWrapper(read_key)
-    scalyr.timeseries('', minutes=start, until=end, align=0)
+    scalyr.timeseries('', minutes=start, end=end, align=0)
 
-    query = get_query('facet', 'count', read_key, **{'minutes': start, 'until': end, 'align': 0})
+    query = get_query('facet', 'count', read_key, **{'minutes': start, 'end': end, 'align': 0})
     query.pop('queryType')
 
     final_q = {

--- a/tests/test_scalyr.py
+++ b/tests/test_scalyr.py
@@ -279,6 +279,8 @@ def get_query(query_type, func, key, **kwargs):
         cur_time = int(time.time())
         end_time = cur_time - (cur_time % kwargs.get('align'))
         start_time = end_time - (kwargs.get('minutes', 5) * 60)
+    elif kwargs.get('until', None) is not None:
+        end_time = str(kwargs.get('until')) + 'm'
 
     q = {
         'token': key,
@@ -526,3 +528,30 @@ def test_scalyr_http_error(monkeypatch, method):
     f = getattr(scalyr, m)
     with pytest.raises(requests.exceptions.HTTPError):
         f(*args)
+
+
+@pytest.mark.parametrize(
+        'until', [(2880, None), (2880, 0), (2880, 1440), (1439, 0)])
+def test_scalyr_timeseries_until(monkeypatch, until):
+    start, end = until
+
+    read_key = '123'
+
+    post = MagicMock()
+    post.return_value.json.return_value = dict({'status': 'success', 'results': [{'values': [1]}]})
+
+    monkeypatch.setattr('requests.post', post)
+
+    scalyr = ScalyrWrapper(read_key)
+    scalyr.timeseries('', minutes=start, until=end, align=0)
+
+    query = get_query('facet', 'count', read_key, **{'minutes': start, 'until': end, 'align': 0})
+    query.pop('queryType')
+
+    final_q = {
+        'token': query.pop('token'),
+        'queries': [query]
+    }
+
+    post.assert_called_with(
+        scalyr._ScalyrWrapper__timeseries_url, json=final_q, headers={'Content-Type': 'application/json'})

--- a/zmon_worker_monitor/builtins/plugins/scalyr.py
+++ b/zmon_worker_monitor/builtins/plugins/scalyr.py
@@ -49,10 +49,11 @@ class ScalyrWrapper(object):
             raise ConfigurationError('Scalyr read key is not set.')
         self.__read_key = read_key
 
-    def count(self, query, minutes=5, align=30):
-        return self.timeseries(query, function='count', minutes=minutes, buckets=1, prio='low', align=align)
+    def count(self, query, minutes=5, align=30, until=None):
+        return self.timeseries(query, function='count', minutes=minutes, buckets=1, prio='low',
+                               align=align, until=until)
 
-    def logs(self, query, max_count=100, minutes=5, continuation_token=None, columns=None):
+    def logs(self, query, max_count=100, minutes=5, continuation_token=None, columns=None, until=None):
 
         if not query or not query.strip():
             raise CheckError('query "{}" is not allowed to be blank'.format(query))
@@ -65,6 +66,8 @@ class ScalyrWrapper(object):
             'startTime': str(minutes) + 'm',
             'priority': 'low'
         }
+        if until is not None:
+            val['endTime'] = str(until) + 'm'
 
         if columns:
             val['columns'] = ','.join(columns) if type(columns) is list else str(columns)
@@ -87,7 +90,7 @@ class ScalyrWrapper(object):
         else:
             raise CheckError('No logs or error message was returned from scalyr')
 
-    def function(self, function, query, minutes=5):
+    def function(self, function, query, minutes=5, until=None):
 
         val = {
             'token': self.__read_key,
@@ -98,6 +101,8 @@ class ScalyrWrapper(object):
             'priority': 'low',
             'buckets': 1
         }
+        if until is not None:
+            val['endTime'] = str(until) + 'm'
 
         r = requests.post(self.__numeric_url, json=val, headers={'Content-Type': 'application/json'})
 
@@ -109,7 +114,7 @@ class ScalyrWrapper(object):
         else:
             return j
 
-    def facets(self, filter, field, max_count=5, minutes=30, prio='low'):
+    def facets(self, filter, field, max_count=5, minutes=30, prio='low', until=None):
 
         val = {
             'token': self.__read_key,
@@ -120,6 +125,8 @@ class ScalyrWrapper(object):
             'startTime': str(minutes) + 'm',
             'priority': prio
         }
+        if until is not None:
+            val['endTime'] = str(until) + 'm'
 
         r = requests.post(self.__facet_url, json=val, headers={'Content-Type': 'application/json'})
 
@@ -128,13 +135,17 @@ class ScalyrWrapper(object):
         j = r.json()
         return j
 
-    def timeseries(self, filter, function='count', minutes=30, buckets=1, prio='low', align=30):
+    def timeseries(self, filter, function='count', minutes=30, buckets=1, prio='low', align=30, until=None):
         start_time = str(minutes) + 'm'
         end_time = None
         if align != 0:
             cur_time = int(time.time())  # this assumes the worker is running with UTC time
+            if until is not None:
+                cur_time = int(time.time()) - 60 * until
             end_time = cur_time - (cur_time % align)
             start_time = end_time - (minutes * 60)
+        elif until is not None:
+            end_time = str(until) + 'm'
 
         val = {
             'token': self.__read_key,


### PR DESCRIPTION
this parameter specifies the number of minutes before now the end of the search time.
When this is not given, the old behaviour of 24 hours (scalyr default) applies. Example
to search for logs from 3 days ago to now is then
 `scalyr().logs(minutes=3*24*60, until=0)`

fixes #349 