### PR TITLE
implement Google Chat Notifications

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ setproctitle
 stups-tokens>=1.0.14
 subprocess32
 timeperiod2==0.1
-Yapsy>=1.11.223
+Yapsy==1.11.223
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ setproctitle
 stups-tokens>=1.0.14
 subprocess32
 timeperiod2==0.1
-Yapsy>=1.10.423
+Yapsy>=1.11.223
 

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -16,7 +16,9 @@ def test_google_hangouts_chat_notification(monkeypatch):
 
     alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'}}
 
-    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link='http://chat.example.org/v1/spaces/XYZ/messages?key=123&token=ABC')
+    r = NotifyGoogleHangoutsChat.notify(alert, 
+                                        message='ALERT', 
+                                        webhook_link='http://chat.example.org/v1/spaces/XYZ/messages?key=123&token=ABC')
 
     data = {
         "cards": [{

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -18,7 +18,7 @@ def test_google_hangouts_chat_notification(monkeypatch):
 
     alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'}}
 
-    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link: 'https://chat.googleapis.com/v1/spaces/XYZ/messages?&key=123&token=ABC')
+    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link='https://chat.googleapis.com/v1/spaces/XYZ/messages?&key=123&token=ABC')
 
     data = {
         "cards": [

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -5,7 +5,6 @@ from zmon_worker_monitor.zmon_worker.notifications.google_hangouts_chat import N
 
 
 HEADERS = {
-    'User-agent': get_user_agent(),
     'Content-type': 'application/json',
 }
 

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -1,0 +1,51 @@
+from mock import MagicMock
+
+from zmon_worker_monitor.zmon_worker.common.http import get_user_agent
+from zmon_worker_monitor.zmon_worker.notifications.google_hangouts_chat import NotifyGoogleHangoutsChat
+
+
+HEADERS = {
+    'User-agent': get_user_agent(),
+    'Content-type': 'application/json',
+}
+
+
+def test_slack_notification(monkeypatch):
+    post = MagicMock()
+    monkeypatch.setattr('requests.post', post)
+
+    alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'},
+             'webhook_link': 'https://chat.googleapis.com/v1/spaces/XYZ/messages?&key=123&token=ABC'}
+
+    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT')
+
+    data = {
+        "cards": [
+            {
+                "sections": [
+                    {
+                        "widgets": [
+                            {
+                                "keyValue": {
+                                    "content": "<font color=\"#FF0000\">ALERT</font>",
+                                    "contentMultiline": "true",
+                                    "onClick": {
+                                         "openLink": {
+                                            "url": "https://example.com/"
+                                         }
+                                     },
+                                    "icon": "FLIGHT_DEPARTURE"
+                                 }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+    assert r == 0
+
+    URL = 'https://chat.googleapis.com/v1/spaces/XYZ/messages?threadKey=123&key=123&token=ABC'
+
+    post.assert_called_with(URL, json=data, headers=HEADERS, timeout=5)

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -9,15 +9,16 @@ HEADERS = {
     'Content-type': 'application/json',
 }
 
+NotifyGoogleHangoutsChat._config = {'zmon.host': 'https://zmon.example.org'}
 
-def test_slack_notification(monkeypatch):
+
+def test_google_hangouts_chat_notification(monkeypatch):
     post = MagicMock()
     monkeypatch.setattr('requests.post', post)
 
-    alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'},
-             'webhook_link': 'https://chat.googleapis.com/v1/spaces/XYZ/messages?&key=123&token=ABC'}
+    alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'}}
 
-    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT')
+    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link: 'https://chat.googleapis.com/v1/spaces/XYZ/messages?&key=123&token=ABC')
 
     data = {
         "cards": [
@@ -27,11 +28,11 @@ def test_slack_notification(monkeypatch):
                         "widgets": [
                             {
                                 "keyValue": {
-                                    "content": "<font color=\"#FF0000\">ALERT</font>",
-                                    "contentMultiline": "true",
+                                    "content": "<font color=\"#FF0000\">NEW ALERT: ALERT!</font>",
+                                    "contentMultiline": "false",
                                     "onClick": {
                                          "openLink": {
-                                            "url": "https://example.com/"
+                                            "url": 'https://zmon.example.org/#/alert-details/123'
                                          }
                                      },
                                     "icon": "FLIGHT_DEPARTURE"

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -16,8 +16,8 @@ def test_google_hangouts_chat_notification(monkeypatch):
 
     alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'}}
 
-    r = NotifyGoogleHangoutsChat.notify(alert, 
-                                        message='ALERT', 
+    r = NotifyGoogleHangoutsChat.notify(alert,
+                                        message='ALERT',
                                         webhook_link='http://chat.example.org/v1/spaces/XYZ/messages?key=123&token=ABC')
 
     data = {

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -20,28 +20,22 @@ def test_google_hangouts_chat_notification(monkeypatch):
     r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link='https://chat.googleapis.com/v1/spaces/XYZ/messages?&key=123&token=ABC')
 
     data = {
-        "cards": [
-            {
-                "sections": [
-                    {
-                        "widgets": [
-                            {
-                                "keyValue": {
-                                    "content": "<font color=\"#FF0000\">NEW ALERT: ALERT!</font>",
-                                    "contentMultiline": "false",
-                                    "onClick": {
-                                         "openLink": {
-                                            "url": 'https://zmon.example.org/#/alert-details/123'
-                                         }
-                                     },
-                                    "icon": "FLIGHT_DEPARTURE"
-                                 }
+        "cards": [{
+            "sections": [{
+                "widgets": [{
+                    "keyValue": {
+                        "onClick": {
+                            "openLink": {
+                                "url": "https://zmon.example.org/#/alert-details/123"
                             }
-                        ]
+                        },
+                        "icon": "FLIGHT_DEPARTURE",
+                        "contentMultiline": "false",
+                        "content": "<font color=\"#FF0000\">NEW ALERT: ALERT!</font>"
                     }
-                ]
-            }
-        ]
+                }]
+            }]
+        }]
     }
 
     assert r == 0

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -17,7 +17,7 @@ def test_google_hangouts_chat_notification(monkeypatch):
 
     alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'}}
 
-    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link='https://chat.googleapis.com/v1/spaces/XYZ/messages?&key=123&token=ABC')
+    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link='https://chat.googleapis.com/v1/spaces/XYZ/messages?key=123&token=ABC')
 
     data = {
         "cards": [{

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -1,6 +1,5 @@
 from mock import MagicMock
 
-from zmon_worker_monitor.zmon_worker.common.http import get_user_agent
 from zmon_worker_monitor.zmon_worker.notifications.google_hangouts_chat import NotifyGoogleHangoutsChat
 
 

--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -17,7 +17,7 @@ def test_google_hangouts_chat_notification(monkeypatch):
 
     alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'}}
 
-    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link='https://chat.googleapis.com/v1/spaces/XYZ/messages?key=123&token=ABC')
+    r = NotifyGoogleHangoutsChat.notify(alert, message='ALERT', webhook_link='http://chat.example.org/v1/spaces/XYZ/messages?key=123&token=ABC')
 
     data = {
         "cards": [{
@@ -40,6 +40,6 @@ def test_google_hangouts_chat_notification(monkeypatch):
 
     assert r == 0
 
-    URL = 'https://chat.googleapis.com/v1/spaces/XYZ/messages?threadKey=123&key=123&token=ABC'
+    URL = 'http://chat.example.org/v1/spaces/XYZ/messages?threadKey=123&key=123&token=ABC'
 
     post.assert_called_with(URL, json=data, headers=HEADERS, timeout=5)

--- a/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
@@ -81,7 +81,8 @@ class NotifyGoogleHangoutsChat(BaseNotification):
             r = requests.post(
                 '{}'.format(webhook_link),
                 json=message,
-                headers={'Content-type': 'application/json'})
+                headers={'Content-type': 'application/json'},
+                timeout=5)
             r.raise_for_status()
         except Exception:
             current_span.set_tag('error', True)

--- a/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 class NotifyGoogleHangoutsChat(BaseNotification):
     @classmethod
-    @trace(operation_name='notification_google_hangouts_chat', 
-           pass_span=True, 
+    @trace(operation_name='notification_google_hangouts_chat',
+           pass_span=True,
            tags={'notification': 'google_hangouts_chat'})
     def notify(cls, alert, *args, **kwargs):
 

--- a/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
@@ -1,0 +1,90 @@
+import logging
+import urllib
+import json
+import traceback
+
+import requests
+
+from urllib2 import urlparse
+
+from opentracing_utils import trace, extract_span_from_kwargs
+
+from notification import BaseNotification
+
+logger = logging.getLogger(__name__)
+
+
+class NotifyGoogleHangoutsChat(BaseNotification):
+    @classmethod
+    @trace(operation_name='notification_google_hangouts_chat', pass_span=True, tags={'notification': 'google_hangouts_chat'})
+    def notify(cls, alert, *args, **kwargs):
+
+        current_span = extract_span_from_kwargs(**kwargs)
+
+        webhook_link = kwargs.get('webhook_link', http://no.webhook.link?wrong)
+        webhook_link_split = webhook_link.split('?')
+        alert_id = alert['alert_def']['id']
+        webhook_link = webhook_link_split[0] + '?threadKey={}&'.format(alert_id) + webhook_link_split[1]
+        
+        repeat = kwargs.get('repeat', 0)
+        alert_def = alert['alert_def']
+        
+        current_span.set_tag('alert_id', alert_def['id'])
+
+        entity = alert.get('entity')
+        is_changed = alert.get('alert_changed', False)
+        is_alert = alert.get('is_alert', False)
+
+        current_span.set_tag('entity', entity['id'])
+        current_span.set_tag('alert_changed', bool(is_changed))
+        current_span.set_tag('is_alert', is_alert)
+
+        current_span.log_kv({'room': kwargs.get('room')})
+
+        color = '#0CB307' if alert and not alert.get('is_alert') else kwargs.get('color', '#FF0000')
+        logo = 'FLIGHT_ARRIVAL' if alert and not alert.get('is_alert') else kwargs.get('logo', 'FLIGHT_DEPARTURE')
+
+        message_text = cls._get_subject(alert, custom_message=kwargs.get('message'))
+
+        zmon_host = kwargs.get('zmon_host', cls._config.get('zmon.host'))
+        alert_url = urlparse.urljoin(zmon_host, '/#/alert-details/{}'.format(alert_id)) if zmon_host else ''
+
+        message = {
+            "cards": [
+                {
+                    "sections": [
+                        {
+                            "widgets": [
+                                {
+                                    "keyValue": {
+                                        "content": '<font color="{}">{}!</font>'.format(color, message_text),
+                                        "contentMultiline": "false",
+                                        "onClick": {
+                                             "openLink": {
+                                                "url": "{}".format(alert_url)
+                                             }
+                                         },
+                                        "icon": "{}".format(logo)
+                                     }
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+
+        try:
+            logger.info(
+                'Sending to: ' + '{}'.format(webhook_link) + ' ' + json.dumps(message))
+            r = requests.post(
+                '{}'.format(webhook_link),
+                json=message, 
+                headers={'Content-type': 'application/json'})
+            r.raise_for_status()
+        except Exception:
+            current_span.set_tag('error', True)
+            current_span.log_kv({'exception': traceback.format_exc()})
+            logger.exception('Google Hangouts Chat write failed!')
+
+        return repeat

--- a/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
@@ -1,5 +1,4 @@
 import logging
-import urllib
 import json
 import traceback
 
@@ -16,7 +15,9 @@ logger = logging.getLogger(__name__)
 
 class NotifyGoogleHangoutsChat(BaseNotification):
     @classmethod
-    @trace(operation_name='notification_google_hangouts_chat', pass_span=True, tags={'notification': 'google_hangouts_chat'})
+    @trace(operation_name='notification_google_hangouts_chat', 
+           pass_span=True, 
+           tags={'notification': 'google_hangouts_chat'})
     def notify(cls, alert, *args, **kwargs):
 
         current_span = extract_span_from_kwargs(**kwargs)
@@ -25,10 +26,10 @@ class NotifyGoogleHangoutsChat(BaseNotification):
         webhook_link_split = webhook_link.split('?')
         alert_id = alert['alert_def']['id']
         webhook_link = webhook_link_split[0] + '?threadKey={}&'.format(alert_id) + webhook_link_split[1]
-        
+
         repeat = kwargs.get('repeat', 0)
         alert_def = alert['alert_def']
-        
+
         current_span.set_tag('alert_id', alert_def['id'])
 
         entity = alert.get('entity')
@@ -79,7 +80,7 @@ class NotifyGoogleHangoutsChat(BaseNotification):
                 'Sending to: ' + '{}'.format(webhook_link) + ' ' + json.dumps(message))
             r = requests.post(
                 '{}'.format(webhook_link),
-                json=message, 
+                json=message,
                 headers={'Content-type': 'application/json'})
             r.raise_for_status()
         except Exception:

--- a/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/google_hangouts_chat.py
@@ -21,7 +21,7 @@ class NotifyGoogleHangoutsChat(BaseNotification):
 
         current_span = extract_span_from_kwargs(**kwargs)
 
-        webhook_link = kwargs.get('webhook_link', http://no.webhook.link?wrong)
+        webhook_link = kwargs.get('webhook_link', 'http://no.webhook.link?wrong')
         webhook_link_split = webhook_link.split('?')
         alert_id = alert['alert_def']['id']
         webhook_link = webhook_link_split[0] + '?threadKey={}&'.format(alert_id) + webhook_link_split[1]

--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -520,6 +520,7 @@ def _build_notify_context(alert):
         'notify_sms': functools.partial(Sms.notify, alert),
         'notify_hubot': functools.partial(Hubot.notify, alert),
         'send_hipchat': functools.partial(NotifyHipchat.notify, alert),
+        'send_google_hangouts_chat': functools.partial(NotifyGoogleHangoutsChat.notify, alert),
         'notify_hipchat': functools.partial(NotifyHipchat.notify, alert),
         'send_slack': functools.partial(NotifySlack.notify, alert),
         'notify_slack': functools.partial(NotifySlack.notify, alert),

--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -49,6 +49,7 @@ from zmon_worker_monitor.zmon_worker.errors import (
     CheckError, AlertError, InsufficientPermissionsError, SecurityError, ResultSizeError)
 from zmon_worker_monitor.zmon_worker.notifications.http import NotifyHttp
 from zmon_worker_monitor.zmon_worker.notifications.hipchat import NotifyHipchat
+from zmon_worker_monitor.zmon_worker.notifications.google_hangouts_chat NotifyGoogleHangoutsChat
 from zmon_worker_monitor.zmon_worker.notifications.hubot import Hubot
 from zmon_worker_monitor.zmon_worker.notifications.mail import Mail
 from zmon_worker_monitor.zmon_worker.notifications.notification import BaseNotification

--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -49,7 +49,7 @@ from zmon_worker_monitor.zmon_worker.errors import (
     CheckError, AlertError, InsufficientPermissionsError, SecurityError, ResultSizeError)
 from zmon_worker_monitor.zmon_worker.notifications.http import NotifyHttp
 from zmon_worker_monitor.zmon_worker.notifications.hipchat import NotifyHipchat
-from zmon_worker_monitor.zmon_worker.notifications.google_hangouts_chat NotifyGoogleHangoutsChat
+from zmon_worker_monitor.zmon_worker.notifications.google_hangouts_chat import NotifyGoogleHangoutsChat
 from zmon_worker_monitor.zmon_worker.notifications.hubot import Hubot
 from zmon_worker_monitor.zmon_worker.notifications.mail import Mail
 from zmon_worker_monitor.zmon_worker.notifications.notification import BaseNotification


### PR DESCRIPTION
implement https://github.com/zalando-zmon/zmon-worker/issues/350

this is a rough copy of the hipchat notification and adapted to Google Chat Hangouts. users need to specify a webhook in the notification and that should be it.

`webhook_link=https://chat.googleapis.com/v1/spaces/<SPACE_ID>/messages?key=<KEY>&token=<TOKEN>`

~~this is completely untested, I don't know how to test it. i also don't know if this is enough to get it going.~~ mainly this should serve as a kickstarter to get this finally going ... ping me to test this in e.g. our K8S cluster ...