### PR TITLE
Add RedisWrapper support for zrange

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
@@ -116,7 +116,7 @@ class RedisWrapper(object):
         return self.__con.zcard(key)
 
     def zrange(self, key, start, end, desc=False, withscores=False, score_cast_func=float):
-        return self.__con.zrange(key, start, end, desc, witschores, score_cast_func)
+        return self.__con.zrange(key, start, end, desc, withscores, score_cast_func)
 
     def statistics(self):
         '''

--- a/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
@@ -115,6 +115,9 @@ class RedisWrapper(object):
     def zcard(self, key):
         return self.__con.zcard(key)
 
+    def zrange(self, key, start, end, desc=False, withscores=False, score_cast_func=float):
+        return self.__con.zrange(key, start, end, desc, witschores, score_cast_func)
+
     def statistics(self):
         '''
         Return general Redis statistics such as operations/s


### PR DESCRIPTION
Hi,

my team currently want's to base a check on result of a redis zrange call. Unfortunately, this does not seem to be directly supported in zmon. However, it seems that redis-py has this functionality (https://redis-py.readthedocs.io/en/latest/#). 