### PR TITLE
Create AWS KMS plugin

### DIFF
--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -1,4 +1,3 @@
-import pytest
 from zmon_worker_monitor.builtins.plugins.kms import KmsWrapper
 
 from mock import MagicMock

--- a/tests/test_kms.py
+++ b/tests/test_kms.py
@@ -1,0 +1,71 @@
+import pytest
+
+from mock import MagicMock
+
+
+ciphertext = 'ciphertext1'
+plaintext = 'plaintext1'
+encryption_context = {
+    'aws:s3:arn': 'arn:aws:s3:::bucket_name/file_name'
+}
+role = 'arn:aws:123456789:role/ROLE'
+region = 'my-region'
+assume_role_resp = {
+    'Credentials': {
+        'AccessKeyId': 'key-1',
+        'SecretAccessKey': 'secret-key-1',
+        'SessionToken': 'session-token-1',
+    }
+}
+
+
+def test_kms_decrypt(monkeypatch):
+    client_mock = MagicMock()
+    client_mock.decrypt.assert_called_with(ciphertext.encode('utf8'))
+    client_mock.decrypt.return_value = plaintext
+    get_mock = MagicMock()
+    get_mock.return_value.json.return_value = {'region': region}
+    monkeypatch.setattr('requests.get', get_mock)
+    monkeypatch.setattr('boto3.client', lambda x, region_name: client_mock)
+
+    kms = KmsWrapper()
+    plaintext_blob = kms.decrypt(ciphertext.encode('utf8'))
+    assert plaintext_blob.decode('utf8') == plaintext
+
+
+def test_kms_decrypt_with_assume_role(monkeypatch):
+    client_mock = MagicMock()
+    client_mock.assume_role.assert_called_with(RoleArn=role, RoleSessionName='zmon-woker-session')
+    client_mock.assume_role.return_value = assume_role_resp
+    client_mock.decrypt.assert_called_with(ciphertext.encode('utf8'))
+    client_mock.decrypt.return_value = plaintext
+    get_mock = MagicMock()
+    get_mock.return_value.json.return_value = {'region': region}
+    session_mock = MagicMock()
+    session_mock.return_value.client.return_value = client
+    session_mock.return_value.client.assert_called_with('cloudwatch', region_name=region)
+    session_mock.assert_called_with(
+        aws_access_key_id=assume_role_resp['Credentials']['AccessKeyId'],
+        aws_secret_access_key=assume_role_resp['Credentials']['SecretAccessKey'],
+        aws_session_token=assume_role_resp['Credentials']['SessionToken'])
+    monkeypatch.setattr('requests.get', get_mock)
+    monkeypatch.setattr('boto3.client', lambda x, region_name: client_mock)
+    monkeypatch.setattr('boto3.Session', session_mock)
+
+    kms = KmsWrapper(region=region, assume_role_arn=role)
+    plaintext_blob = kms.decrypt(ciphertext.encode('utf8'))
+    assert plaintext_blob.decode('utf8') == plaintext
+
+
+def test_kms_decrypt_encryption_context(monkeypatch):
+    client_mock = MagicMock()
+    client_mock.decrypt.assert_called_with(ciphertext.encode('utf8'), encryption_context)
+    client_mock.decrypt.return_value = plaintext
+    get_mock = MagicMock()
+    get_mock.return_value.json.return_value = {'region': region}
+    monkeypatch.setattr('requests.get', get_mock)
+    monkeypatch.setattr('boto3.client', lambda x, region_name: client_mock)
+
+    kms = KmsWrapper()
+    plaintext_blob = kms.decrypt(ciphertext.encode('utf8'), encryption_context)
+    assert plaintext_blob.decode('utf8') == plaintext

--- a/zmon_worker_monitor/builtins/plugins/kms.py
+++ b/zmon_worker_monitor/builtins/plugins/kms.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import boto3
+import logging
+
+from zmon_worker_monitor.builtins.plugins.aws_common import get_instance_identity_document
+from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
+
+logging.getLogger('botocore').setLevel(logging.WARN)
+
+logger = logging.getLogger('zmon-worker.cloudwatch')
+
+
+class KmsWrapperFactory(IFunctionFactoryPlugin):
+    def __init__(self):
+        super(KmsWrapperFactory, self).__init__()
+
+    def configure(self, conf):
+        return
+
+    def create(self, factory_ctx):
+        """
+        Automatically called to create the check function's object
+        :param factory_ctx: (dict) names available for Function instantiation
+        :return: an object that implements a check function
+        """
+        return propartial(KmsWrapper, region=factory_ctx.get('entity').get('region', None))
+
+class KmsWrapper(object):
+    def __init__(self, region=None, assume_role_arn=None):
+        if not region:
+            region = get_instance_identity_document()['region']
+        self.__client = boto3.client('kms', region_name=region)
+
+        if assume_role_arn:
+            sts = boto3.client('sts', region_name=region)
+            resp = sts.assume_role(RoleArn=assume_role_arn, RoleSessionName='zmon-woker-session')
+            session = boto3.Session(aws_access_key_id=resp['Credentials']['AccessKeyId'],
+                                    aws_secret_access_key=resp['Credentials']['SecretAccessKey'],
+                                    aws_session_token=resp['Credentials']['SessionToken'])
+            self.__client = session.client('kms', region_name=region)
+            logger.debug('kms wrapper assumed role: {}'.format(assume_role_arn))
+
+    def decrypt(self, ciphertext_blob, encryption_context=None):
+        """
+        Invokes kms_client.decrypt() of boto3.
+        :param ciphertext_blob: (bytes) required, the ciphertext blob to be decrypt.
+        :param encryption_context: (dict) optional, encryption_context that was specified when encrypting.
+        :return: (bytes) plaintext blob
+        """
+        kwargs = { 'CiphertextBlob': ciphertext_blob }
+        if encryption_context:
+            logger.debug('encryption_context provided: ', encryption_context)
+            kwargs['EncryptionContext'] = encryption_context
+        return self._client.decrypt(**kwargs)

--- a/zmon_worker_monitor/builtins/plugins/kms.py
+++ b/zmon_worker_monitor/builtins/plugins/kms.py
@@ -27,6 +27,7 @@ class KmsWrapperFactory(IFunctionFactoryPlugin):
         """
         return propartial(KmsWrapper, region=factory_ctx.get('entity').get('region', None))
 
+
 class KmsWrapper(object):
     def __init__(self, region=None, assume_role_arn=None):
         if not region:
@@ -49,7 +50,7 @@ class KmsWrapper(object):
         :param encryption_context: (dict) optional, encryption_context that was specified when encrypting.
         :return: (bytes) plaintext blob
         """
-        kwargs = { 'CiphertextBlob': ciphertext_blob }
+        kwargs = {'CiphertextBlob': ciphertext_blob}
         if encryption_context:
             logger.debug('encryption_context provided: ', encryption_context)
             kwargs['EncryptionContext'] = encryption_context

--- a/zmon_worker_monitor/builtins/plugins/kms.py
+++ b/zmon_worker_monitor/builtins/plugins/kms.py
@@ -54,4 +54,4 @@ class KmsWrapper(object):
         if encryption_context:
             logger.debug('encryption_context provided: ', encryption_context)
             kwargs['EncryptionContext'] = encryption_context
-        return self._client.decrypt(**kwargs)
+        return self.__client.decrypt(**kwargs)

--- a/zmon_worker_monitor/builtins/plugins/kms.worker_plugin
+++ b/zmon_worker_monitor/builtins/plugins/kms.worker_plugin
@@ -1,0 +1,11 @@
+[Core]
+Name = kms
+Module = kms
+
+[Documentation]
+Author = Ire Sun
+Version = 0.1
+Website = https://github.com/zalando/zmon-worker
+Description = Builtin plugin that provides an KMS decrypt function
+
+[Configuration]


### PR DESCRIPTION
As all checks are visible to the whole organization, it makes RESTful APIs with bearer token infeasible. If we have KMS in check definitions, we can use the access token in check without disclosing to everyone in the organization.

Please review, any feedbacks are appreciated. 😁