### PR TITLE
fix empty env var passed as user

### DIFF
--- a/zmon_worker_monitor/zmon_worker/notifications/mail.py
+++ b/zmon_worker_monitor/zmon_worker/notifications/mail.py
@@ -156,7 +156,7 @@ class Mail(BaseNotification):
             else:
                 try:
                     mail_user = cls._config.get('notifications.mail.user', None)
-                    if mail_user is not None:
+                    if mail_user:
                         if not is_protected:
                             raise NotificationError(
                                     'Mail server ({}) does not support TLS / STARTTLS!'.format(mail_host))


### PR DESCRIPTION
this may happen if the docker image is wrapping one where the env is set and we need to override it