### PR TITLE
added safe check for unicode types and unit testing

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 import Queue
 
 from mock import MagicMock
 
-from zmon_worker_monitor.zmon_worker.common.utils import PeriodicBufferedAction
+from zmon_worker_monitor.zmon_worker.common.utils import flatten, PeriodicBufferedAction
+
 
 
 def test_periodic_buffered_action(monkeypatch):
@@ -81,3 +83,9 @@ def test_periodic_buffered_action_loop_sleep(monkeypatch):
     pba.start()
     pba._loop()
     assert handle['slept']
+
+
+def test_flatten_unicode():
+    assert flatten({'a': {'b': 'c'}, 'd': 'e'}) == {'d': 'e', 'a.b': 'c'}
+    assert flatten({'a': {'ü': 'c'}, 'd': 'e'}) == {'d': 'e', 'a.ü': 'c'}
+    assert flatten({'a': {'ü'.decode("utf-8"): 'c'}, 'd': 'e'}) == {'d': 'e', 'a.ü': 'c'}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ from mock import MagicMock
 from zmon_worker_monitor.zmon_worker.common.utils import flatten, PeriodicBufferedAction
 
 
-
 def test_periodic_buffered_action(monkeypatch):
     thread = MagicMock()
     sleep = MagicMock()

--- a/zmon_worker_monitor/zmon_worker/common/utils.py
+++ b/zmon_worker_monitor/zmon_worker/common/utils.py
@@ -14,10 +14,8 @@ def flatten(structure, key='', path='', flattened=None):
     >>> sorted(flatten({'a': {'b': 'c'}, 'd': 'e'}).items())
     [('a.b', 'c'), ('d', 'e')]
     '''
-    if isinstance(path, unicode):
-        path = path.encode("utf-8")
-    if isinstance(key, unicode):
-        key = key.encode("utf-8")
+    path = path.encode("utf-8") if isinstance(path, unicode) else str(path)
+    key = key.encode("utf-8") if isinstance(key, unicode) else str(key)
 
     if flattened is None:
         flattened = {}

--- a/zmon_worker_monitor/zmon_worker/common/utils.py
+++ b/zmon_worker_monitor/zmon_worker/common/utils.py
@@ -14,8 +14,10 @@ def flatten(structure, key='', path='', flattened=None):
     >>> sorted(flatten({'a': {'b': 'c'}, 'd': 'e'}).items())
     [('a.b', 'c'), ('d', 'e')]
     '''
-    path = str(path)
-    key = str(key)
+    if isinstance(path, unicode):
+        path = path.encode("utf-8")
+    if isinstance(key, unicode):
+        key = key.encode("utf-8")
 
     if flattened is None:
         flattened = {}


### PR DESCRIPTION
## Problem
Encodings in python 2 have always been pretty messy due to implicit conversion done behind the curtains. 
Essentially there are two types of objects: `str` and `unicode`. The former are just bytes, while the latter contain the metadata needed. 

When we have in our code something like:

```
key = str(key)
```

python internally performs the following: 

if it is a `str` type it is an idempotent function, since bytes are bytes.
if it is a `unicode` type it makes an implicit conversion to `ascii`. Which is risky since the text contained in there might be not ascii. 

## Impact

the function `prometheus_flat()` is using this flatten utility, and it fails whenever the text contains non-ascii characters

 ## Solution
I have strived for doing an explicit conversion only if it is needed.

