### PR TITLE
Return Redis `maxmemory` statistics

### DIFF
--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -16,8 +16,10 @@ STATS = {
     "instantaneous_ops_per_sec": 29626,
     "keyspace_hits_per_sec": 1195.43,
     "keyspace_misses_per_sec": 1237.99,
+    "maxmemory": 152343648,
     "used_memory": 50781216,
     "used_memory_rss": 63475712,
+    "used_memory_lua": 475712,
     "foo": "bar"
 }
 

--- a/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
@@ -17,7 +17,9 @@ STATISTIC_GAUGE_KEYS = frozenset([
     'master_repl_offset',
     'role',
     'slave0',
+    'maxmemory',
     'used_memory',
+    'used_memory_lua',
     'used_memory_peak',
     'used_memory_rss',
 ])


### PR DESCRIPTION
See https://redis.io/commands/info#return-value