### PR TITLE
allow passing ssl and ssl_cert_reqs to redis()

### DIFF
--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -81,5 +81,7 @@ def test_redis_parametrized(monkeypatch, kwargs):
         kwargs.get('db', 0),
         kwargs.get('password'),
         socket_connect_timeout=kwargs.get('socket_connect_timeout', 1),
-        socket_timeout=kwargs.get('socket_timeout', 5)
+        socket_timeout=kwargs.get('socket_timeout', 5),
+        ssl=False,
+        ssl_cert_reqs='required'
     )

--- a/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
@@ -70,7 +70,9 @@ class RedisFactory(IFunctionFactoryPlugin):
 class RedisWrapper(object):
     '''Class to allow only readonly access to underlying redis connection'''
 
-    def __init__(self, counter, host, port=6379, db=0, password=None, socket_connect_timeout=1, socket_timeout=5, ssl=False, ssl_cert_reqs='required'):
+    def __init__(self, counter, host, port=6379, db=0, password=None,
+                 socket_connect_timeout=1, socket_timeout=5, ssl=False,
+                 ssl_cert_reqs='required'):
         if not host:
             raise ConfigurationError('Redis wrapper improperly configured. Valid redis host is required!')
 

--- a/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
+++ b/zmon_worker_monitor/builtins/plugins/redis_wrapper.py
@@ -70,7 +70,7 @@ class RedisFactory(IFunctionFactoryPlugin):
 class RedisWrapper(object):
     '''Class to allow only readonly access to underlying redis connection'''
 
-    def __init__(self, counter, host, port=6379, db=0, password=None, socket_connect_timeout=1, socket_timeout=5):
+    def __init__(self, counter, host, port=6379, db=0, password=None, socket_connect_timeout=1, socket_timeout=5, ssl=False, ssl_cert_reqs='required'):
         if not host:
             raise ConfigurationError('Redis wrapper improperly configured. Valid redis host is required!')
 
@@ -81,7 +81,9 @@ class RedisWrapper(object):
             db,
             password,
             socket_connect_timeout=socket_connect_timeout,
-            socket_timeout=socket_timeout
+            socket_timeout=socket_timeout,
+            ssl=ssl,
+            ssl_cert_reqs=ssl_cert_reqs
         )
 
     def llen(self, key):


### PR DESCRIPTION
This PR changes the `redis()` check command to support the `ssl` and `ssl_cert_reqs` parameters of the underlying py-redis library. https://redis-py.readthedocs.io/en/latest/#redis.Redis

This is needed to support connecting to Redis instances that use SSL such as AWS ElastiCache Redis with `TransitEncryptionEnabled`.