### PR TITLE
Kubernetes plugin: optimise queries

### DIFF
--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -1,16 +1,19 @@
-import contextlib
-
 import pykube
 import pytest
 from mock import MagicMock
 
-from zmon_worker_monitor.builtins.plugins.kubernetes import KubernetesWrapper, CheckError, _get_resources
+from zmon_worker_monitor.builtins.plugins.kubernetes import (
+    KubernetesWrapper,
+    CheckError,
+    _get_resources,
+)
 
-CLUSTER_URL = 'https://kube-cluster.example.org'
+CLUSTER_URL = "https://kube-cluster.example.org"
 
 
 def resource_mock(name, **kwargs):
-    resource = MagicMock(name='pykube-{}'.format(name))
+    resource = MagicMock(name="pykube-{}".format(name))
+    resource.name = name
     resource.obj = MagicMock(name=name)
 
     for k, v in kwargs.items():
@@ -19,47 +22,70 @@ def resource_mock(name, **kwargs):
     return resource
 
 
-def get_resources_mock(res):
-    get = MagicMock()
-    get.return_value = res
+class MockWrapper:
+    def __init__(self, monkeypatch, kind, namespace, resources):
+        self._query = MagicMock(name="query")
+        self._object_manager = MagicMock(name="object_manager")
+        self._object_manager.objects.return_value = self._query
 
-    return get
+        self._get_resources = MagicMock("get_resources")
+        self._get_resources.return_value = resources
+
+        monkeypatch.setattr("pykube.{}".format(kind), self._object_manager)
+        monkeypatch.setattr(
+            "zmon_worker_monitor.builtins.plugins.kubernetes._get_resources",
+            self._get_resources,
+        )
+
+        self._client = client_mock(monkeypatch)
+        self.wrapper = KubernetesWrapper(namespace=namespace)
+
+    def assert_objects_called(self, expected_namespace=None):
+        if expected_namespace is not None:
+            self._object_manager.objects.assert_called_once_with(
+                self._client, expected_namespace
+            )
+        else:
+            self._object_manager.objects.assert_called_once_with(self._client)
+
+    def assert_get_resources_called(self, expected_args):
+        self._get_resources.assert_called_once_with(self._query, **expected_args)
 
 
 def client_mock(monkeypatch):
-    monkeypatch.setattr('pykube.KubeConfig', MagicMock())
-    client = MagicMock(name='client')
-    monkeypatch.setattr('pykube.HTTPClient', lambda *args, **kwargs: client)
+    monkeypatch.setattr("pykube.KubeConfig", MagicMock())
+    client = MagicMock(name="client")
+    monkeypatch.setattr("pykube.HTTPClient", lambda *args, **kwargs: client)
     return client
 
 
 def test_get_resources_named():
-    resource = MagicMock(name='resource')
+    resource = MagicMock(name="resource")
 
     manager = MagicMock()
-    manager.namespace = 'default'
+    manager.namespace = "default"
     manager.get_by_name.return_value = resource
 
-    assert [resource] == _get_resources(manager, name='foo')
-    manager.get_by_name.assert_called_once_with('foo')
+    assert [resource] == _get_resources(manager, name="foo")
+    manager.get_by_name.assert_called_once_with("foo")
 
 
 def test_get_resources_named_no_resource():
     manager = MagicMock()
-    manager.namespace = 'default'
+    manager.namespace = "default"
     manager.get_by_name.side_effect = pykube.exceptions.ObjectDoesNotExist()
 
-    assert [] == _get_resources(manager, name='foo')
-    manager.get_by_name.assert_called_once_with('foo')
+    assert [] == _get_resources(manager, name="foo")
+    manager.get_by_name.assert_called_once_with("foo")
 
 
 @pytest.mark.parametrize(
-    'namespace,phase,kwargs',
+    "namespace,phase,kwargs",
     [
         (pykube.all, None, {}),
-        ('default', 'Pending', {}),
-        ('default', None, {'application': 'foo'})
-    ]
+        ("default", "Pending", {}),
+        ("default", None, {"application": "foo"}),
+    ],
 )
 def test_get_resources_unsupported(namespace, phase, kwargs):
     manager = MagicMock()
@@ -67,20 +93,26 @@ def test_get_resources_unsupported(namespace, phase, kwargs):
     manager.get_by_name.return_value = None
 
     with pytest.raises(CheckError):
-        _get_resources(manager, name='foo', phase=phase, **kwargs)
+        _get_resources(manager, name="foo", phase=phase, **kwargs)
 
     manager.get_by_name.assert_not_called()
 
 
 @pytest.mark.parametrize(
-    'phase,kwargs,query',
+    "phase,kwargs,query",
     [
         (None, {}, {}),
-        ('Pending', {}, {'field_selector': {'status.phase': 'Pending'}}),
-        (None, {'application': 'foo'}, {'selector': {'application': 'foo'}}),
-        ('Pending', {'application': 'foo'}, {'field_selector': {'status.phase': 'Pending'},
-                                             'selector': {'application': 'foo'}}),
-    ]
+        ("Pending", {}, {"field_selector": {"status.phase": "Pending"}}),
+        (None, {"application": "foo"}, {"selector": {"application": "foo"}}),
+        (
+            "Pending",
+            {"application": "foo"},
+            {
+                "field_selector": {"status.phase": "Pending"},
+                "selector": {"application": "foo"},
+            },
+        ),
+    ],
 )
 def test_get_resources_filter(phase, kwargs, query):
     manager = MagicMock()
@@ -91,26 +123,50 @@ def test_get_resources_filter(phase, kwargs, query):
 
 
 @pytest.mark.parametrize(
-    'kwargs,filter_kwargs,res',
+    "kwargs,filter_kwargs,res",
     [
         (
-            {}, {},
+            {},
+            {},
             [
-                resource_mock({'metadata': {'name': 'pod-1'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'pod-2'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'pod-3'}, 'spec': {}, 'status': {}}),
-            ]
+                resource_mock(
+                    {"metadata": {"name": "pod-1"}, "spec": {}, "status": {}}
+                ),
+                resource_mock(
+                    {"metadata": {"name": "pod-2"}, "spec": {}, "status": {}}
+                ),
+                resource_mock(
+                    {"metadata": {"name": "pod-3"}, "spec": {}, "status": {}}
+                ),
+            ],
         ),
         (
-            {'application': 'pod-1', 'phase': 'Running', 'ready': True},
-            {'selector': {'application': 'pod-1'}, 'field_selector': {'status.phase': 'Running'}},
-            [resource_mock({'metadata': {'name': 'pod-1'}, 'spec': {}, 'status': {'phase': 'Running'}})]
+            {"application": "pod-1", "phase": "Running", "ready": True},
+            {
+                "selector": {"application": "pod-1"},
+                "field_selector": {"status.phase": "Running"},
+            },
+            [
+                resource_mock(
+                    {
+                        "metadata": {"name": "pod-1"},
+                        "spec": {},
+                        "status": {"phase": "Running"},
+                    }
+                )
+            ],
         ),
         (
-            {'name': 'pod-2', 'ready': False}, {'field_selector': {'metadata.name': 'pod-2'}},
-            [resource_mock({'metadata': {'name': 'pod-2'}, 'spec': {}, 'status': {}}, ready=False)]
+            {"name": "pod-2", "ready": False},
+            {"field_selector": {"metadata.name": "pod-2"}},
+            [
+                resource_mock(
+                    {"metadata": {"name": "pod-2"}, "spec": {}, "status": {}},
+                    ready=False,
+                )
+            ],
         ),
-    ]
+    ],
 )
 def test_pods(monkeypatch, kwargs, filter_kwargs, res):
     client_mock(monkeypatch)
@@ -120,8 +176,10 @@ def test_pods(monkeypatch, kwargs, filter_kwargs, res):
     query = pod.objects.return_value.filter.return_value
 
     monkeypatch.setattr(
-        'zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources', get_resources)
-    monkeypatch.setattr('pykube.Pod', pod)
+        "zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources",
+        get_resources,
+    )
+    monkeypatch.setattr("pykube.Pod", pod)
 
     k = KubernetesWrapper()
 
@@ -133,7 +191,7 @@ def test_pods(monkeypatch, kwargs, filter_kwargs, res):
     pod.objects.return_value.filter.assert_called_with(**filter_kwargs)
 
 
-@pytest.mark.parametrize('kwargs', ({'ready': 1}, {'ready': 0}, {'phase': 'WRONG'}))
+@pytest.mark.parametrize("kwargs", ({"ready": 1}, {"ready": 0}, {"phase": "WRONG"}))
 def test_pods_error(kwargs):
     k = KubernetesWrapper()
 
@@ -144,11 +202,11 @@ def test_pods_error(kwargs):
 def test_namespaces(monkeypatch):
     client_mock(monkeypatch)
 
-    res = [resource_mock({'metadata': {}})]
+    res = [resource_mock({"metadata": {}})]
 
     ns = MagicMock()
     ns.objects.return_value.all.return_value = res
-    monkeypatch.setattr('pykube.Namespace', ns)
+    monkeypatch.setattr("pykube.Namespace", ns)
 
     k = KubernetesWrapper()
     namespaces = k.namespaces()
@@ -156,171 +214,314 @@ def test_namespaces(monkeypatch):
     assert [r.obj for r in res] == namespaces
 
 
-@contextlib.contextmanager
-def pykube_mock(monkeypatch, kind,
-                namespace, expected_namespace,
-                expected_args, resources):
-    query = MagicMock(name='query')
-
-    object_manager = MagicMock(name='object_manager')
-    object_manager.objects.return_value = query
-
-    get_resources = MagicMock('get_resources')
-    get_resources.return_value = resources
-
-    monkeypatch.setattr('pykube.{}'.format(kind), object_manager)
-    monkeypatch.setattr('zmon_worker_monitor.builtins.plugins.kubernetes._get_resources', get_resources)
-
-    client = client_mock(monkeypatch)
-    wrapper = KubernetesWrapper(namespace=namespace)
-
-    yield wrapper
-
-    if expected_namespace is not None:
-        object_manager.objects.assert_called_once_with(client, expected_namespace)
-    else:
-        object_manager.objects.assert_called_once_with(client)
-
-    get_resources.assert_called_once_with(query, **expected_args)
-
-
 @pytest.mark.parametrize(
-    'namespace,name,kwargs,expected_query,objects',
+    "namespace,name,kwargs,expected_query,objects",
     [
-        (None, 'foo', {}, {'name': 'foo'}, [resource_mock(name='node-1')]),
-        ('default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='node-1')]),
-        (None, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='node-1')]),
-        ('default', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='node-1'), resource_mock(name='node-2')]),
-    ]
+        (None, "foo", {}, {"name": "foo"}, [resource_mock(name="node-1")]),
+        ("default", "foo", {}, {"name": "foo"}, [resource_mock(name="node-1")]),
+        (
+            None,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="node-1")],
+        ),
+        (
+            "default",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="node-1"), resource_mock(name="node-2")],
+        ),
+    ],
 )
 def test_nodes(monkeypatch, namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'Node', namespace, None, expected_query, objects) as wrapper:
-        nodes = wrapper.nodes(name=name, **kwargs)
-        assert [r.obj for r in objects] == nodes
+    mock = MockWrapper(monkeypatch, "Node", namespace, objects)
+    nodes = mock.wrapper.nodes(name=name, **kwargs)
+    assert [r.obj for r in objects] == nodes
+    mock.assert_objects_called(expected_namespace=None)
+    mock.assert_get_resources_called(expected_query)
 
 
 @pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
     [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='svc-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='svc-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='svc-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='svc-1'), resource_mock(name='svc-2')]),
-    ]
+        (None, pykube.all, "foo", {}, {"name": "foo"}, [resource_mock(name="svc-1")]),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="svc-1")],
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="svc-1")],
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="svc-1"), resource_mock(name="svc-2")],
+        ),
+    ],
 )
-def test_services(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'Service', namespace, expected_namespace, expected_query, objects) as wrapper:
-        services = wrapper.services(name=name, **kwargs)
-        assert [r.obj for r in objects] == services
+def test_services(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "Service", namespace, objects)
+    services = mock.wrapper.services(name=name, **kwargs)
+    assert [r.obj for r in objects] == services
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
 
 
 @pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
     [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='ep-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='ep-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='ep-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='ep-1'), resource_mock(name='ep-2')]),
-    ]
+        (None, pykube.all, "foo", {}, {"name": "foo"}, [resource_mock(name="ep-1")]),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="ep-1")],
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="ep-1")],
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="ep-1"), resource_mock(name="ep-2")],
+        ),
+    ],
 )
-def test_endpoints(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'Endpoint', namespace, expected_namespace, expected_query, objects) as wrapper:
-        endpoints = wrapper.endpoints(name=name, **kwargs)
-        assert [r.obj for r in objects] == endpoints
+def test_endpoints(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "Endpoint", namespace, objects)
+    endpoints = mock.wrapper.endpoints(name=name, **kwargs)
+    assert [r.obj for r in objects] == endpoints
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
 
 
 @pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
-    [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='ingress-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='ingress-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='ingress-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='ingress-1'), resource_mock(name='ingress-2')]),
-    ]
-)
-def test_ingresses(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'Ingress', namespace, expected_namespace, expected_query, objects) as wrapper:
-        ingresses = wrapper.ingresses(name=name, **kwargs)
-        assert [r.obj for r in objects] == ingresses
-
-
-@pytest.mark.parametrize(
-    'kwargs,filter_kwargs,res',
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
     [
         (
-            {}, {},
+            None,
+            pykube.all,
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="ingress-1")],
+        ),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="ingress-1")],
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="ingress-1")],
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="ingress-1"), resource_mock(name="ingress-2")],
+        ),
+    ],
+)
+def test_ingresses(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "Ingress", namespace, objects)
+    ingresses = mock.wrapper.ingresses(name=name, **kwargs)
+    assert [r.obj for r in objects] == ingresses
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
+
+
+@pytest.mark.parametrize(
+    "namespace,expected_namespace,replicas,name,kwargs,expected_query,objects,expected_objects",
+    [
+        (
+            None,
+            pykube.all,
+            None,
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="ss-1", replicas=1)],
+            {"ss-1"},
+        ),
+        (
+            "default",
+            "default",
+            None,
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="ss-1", replicas=1)],
+            {"ss-1"},
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="ss-1", replicas=1)],
+            {"ss-1"},
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
             [
-                resource_mock({'metadata': {'name': 'ss-1'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'ss-2'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'ss-3'}, 'spec': {}, 'status': {}}),
-            ]
+                resource_mock(name="ss-1", replicas=1),
+                resource_mock(name="ss-2", replicas=1),
+            ],
+            {"ss-1", "ss-2"},
         ),
         (
-            {'application': 'ss-1', 'replicas': 2}, {'selector': {'application': 'ss-1'}},
-            [resource_mock({'metadata': {'name': 'ss-1'}, 'spec': {}, 'status': {'replicas': '2'}}, replicas=2)]
-        ),
-        (
-            {'name': 'ss-2'}, {'field_selector': {'metadata.name': 'ss-2'}},
-            [resource_mock({'metadata': {'name': 'ss-2'}, 'spec': {}, 'status': {}})]
-        ),
-    ]
-)
-def test_statefulsets(monkeypatch, kwargs, filter_kwargs, res):
-    client_mock(monkeypatch)
-    get_resources = get_resources_mock(res)
-
-    statefulset = MagicMock()
-    query = statefulset.objects.return_value.filter.return_value
-
-    monkeypatch.setattr(
-        'zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources', get_resources)
-    monkeypatch.setattr('pykube.StatefulSet', statefulset)
-
-    k = KubernetesWrapper()
-
-    statefulsets = k.statefulsets(**kwargs)
-
-    assert [r.obj for r in res] == statefulsets
-
-    get_resources.assert_called_with(query)
-    statefulset.objects.return_value.filter.assert_called_with(**filter_kwargs)
-
-
-@pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
-    [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='ds-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='ds-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='ds-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='ds-1'), resource_mock(name='ds-2')]),
-    ]
-)
-def test_daemonsets(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'DaemonSet', namespace, expected_namespace, expected_query, objects) as wrapper:
-        daemonsets = wrapper.daemonsets(name=name, **kwargs)
-        assert [r.obj for r in objects] == daemonsets
-
-
-@pytest.mark.parametrize(
-    'kwargs,filter_kwargs,res',
-    [
-        (
-            {}, {},
+            "foobar",
+            "foobar",
+            2,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
             [
-                resource_mock({'metadata': {'name': 'rs-1'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'rs-2'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'rs-3'}, 'spec': {}, 'status': {}}),
-            ]
+                resource_mock(name="ss-1", replicas=1),
+                resource_mock(name="ss-2", replicas=2),
+                resource_mock(name="ss-3", replicas=2),
+            ],
+            {"ss-2", "ss-3"},
+        ),
+    ],
+)
+def test_statefulsets(
+    monkeypatch,
+    namespace,
+    expected_namespace,
+    replicas,
+    name,
+    kwargs,
+    expected_query,
+    objects,
+    expected_objects,
+):
+    mock = MockWrapper(monkeypatch, "StatefulSet", namespace, objects)
+    statefulsets = mock.wrapper.statefulsets(name=name, replicas=replicas, **kwargs)
+    assert [r.obj for r in objects if r.name in expected_objects] == statefulsets
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
+
+
+@pytest.mark.parametrize(
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
+    [
+        (None, pykube.all, "foo", {}, {"name": "foo"}, [resource_mock(name="ds-1")]),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="ds-1")],
         ),
         (
-            {'application': 'rs-1', 'replicas': 2}, {'selector': {'application': 'rs-1'}},
-            [resource_mock({'metadata': {'name': 'rs-1'}, 'spec': {}, 'status': {'replicas': '2'}}, replicas=2)]
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="ds-1")],
         ),
         (
-            {'name': 'rs-2'}, {'field_selector': {'metadata.name': 'rs-2'}},
-            [resource_mock({'metadata': {'name': 'rs-2'}, 'spec': {}, 'status': {}})]
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="ds-1"), resource_mock(name="ds-2")],
         ),
-    ]
+    ],
+)
+def test_daemonsets(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "DaemonSet", namespace, objects)
+    daemonsets = mock.wrapper.daemonsets(name=name, **kwargs)
+    assert [r.obj for r in objects] == daemonsets
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
+
+
+@pytest.mark.parametrize(
+    "kwargs,filter_kwargs,res",
+    [
+        (
+            {},
+            {},
+            [
+                resource_mock({"metadata": {"name": "rs-1"}, "spec": {}, "status": {}}),
+                resource_mock({"metadata": {"name": "rs-2"}, "spec": {}, "status": {}}),
+                resource_mock({"metadata": {"name": "rs-3"}, "spec": {}, "status": {}}),
+            ],
+        ),
+        (
+            {"application": "rs-1", "replicas": 2},
+            {"selector": {"application": "rs-1"}},
+            [
+                resource_mock(
+                    {
+                        "metadata": {"name": "rs-1"},
+                        "spec": {},
+                        "status": {"replicas": "2"},
+                    },
+                    replicas=2,
+                )
+            ],
+        ),
+        (
+            {"name": "rs-2"},
+            {"field_selector": {"metadata.name": "rs-2"}},
+            [resource_mock({"metadata": {"name": "rs-2"}, "spec": {}, "status": {}})],
+        ),
+    ],
 )
 def test_replicasets(monkeypatch, kwargs, filter_kwargs, res):
     client_mock(monkeypatch)
@@ -330,8 +531,10 @@ def test_replicasets(monkeypatch, kwargs, filter_kwargs, res):
     query = replicaset.objects.return_value.filter.return_value
 
     monkeypatch.setattr(
-        'zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources', get_resources)
-    monkeypatch.setattr('pykube.ReplicaSet', replicaset)
+        "zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources",
+        get_resources,
+    )
+    monkeypatch.setattr("pykube.ReplicaSet", replicaset)
 
     k = KubernetesWrapper()
 
@@ -344,25 +547,43 @@ def test_replicasets(monkeypatch, kwargs, filter_kwargs, res):
 
 
 @pytest.mark.parametrize(
-    'kwargs,filter_kwargs,res',
+    "kwargs,filter_kwargs,res",
     [
         (
-            {}, {},
+            {},
+            {},
             [
-                resource_mock({'metadata': {'name': 'dep-1'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'dep-2'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'dep-3'}, 'spec': {}, 'status': {}}),
-            ]
+                resource_mock(
+                    {"metadata": {"name": "dep-1"}, "spec": {}, "status": {}}
+                ),
+                resource_mock(
+                    {"metadata": {"name": "dep-2"}, "spec": {}, "status": {}}
+                ),
+                resource_mock(
+                    {"metadata": {"name": "dep-3"}, "spec": {}, "status": {}}
+                ),
+            ],
         ),
         (
-            {'application': 'dep-1', 'replicas': 2}, {'selector': {'application': 'dep-1'}},
-            [resource_mock({'metadata': {'name': 'dep-1'}, 'spec': {}, 'status': {'replicas': '2'}}, replicas=2)]
+            {"application": "dep-1", "replicas": 2},
+            {"selector": {"application": "dep-1"}},
+            [
+                resource_mock(
+                    {
+                        "metadata": {"name": "dep-1"},
+                        "spec": {},
+                        "status": {"replicas": "2"},
+                    },
+                    replicas=2,
+                )
+            ],
         ),
         (
-            {'name': 'dep-2'}, {'field_selector': {'metadata.name': 'dep-2'}},
-            [resource_mock({'metadata': {'name': 'dep-2'}, 'spec': {}, 'status': {}})]
+            {"name": "dep-2"},
+            {"field_selector": {"metadata.name": "dep-2"}},
+            [resource_mock({"metadata": {"name": "dep-2"}, "spec": {}, "status": {}})],
         ),
-    ]
+    ],
 )
 def test_deployments(monkeypatch, kwargs, filter_kwargs, res):
     client_mock(monkeypatch)
@@ -372,8 +593,10 @@ def test_deployments(monkeypatch, kwargs, filter_kwargs, res):
     query = deployment.objects.return_value.filter.return_value
 
     monkeypatch.setattr(
-        'zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources', get_resources)
-    monkeypatch.setattr('pykube.Deployment', deployment)
+        "zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources",
+        get_resources,
+    )
+    monkeypatch.setattr("pykube.Deployment", deployment)
 
     k = KubernetesWrapper()
 
@@ -385,7 +608,7 @@ def test_deployments(monkeypatch, kwargs, filter_kwargs, res):
     deployment.objects.return_value.filter.assert_called_with(**filter_kwargs)
 
 
-@pytest.mark.parametrize('kwargs', ({'ready': 1}, {'ready': 0}))
+@pytest.mark.parametrize("kwargs", ({"ready": 1}, {"ready": 0}))
 def test_deployments_error(monkeypatch, kwargs):
     k = KubernetesWrapper()
 
@@ -394,40 +617,82 @@ def test_deployments_error(monkeypatch, kwargs):
 
 
 @pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
     [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='cfg-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='cfg-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='cfg-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='cfg-1'), resource_mock(name='cfg-2')]),
-    ]
+        (None, pykube.all, "foo", {}, {"name": "foo"}, [resource_mock(name="cfg-1")]),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="cfg-1")],
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="cfg-1")],
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="cfg-1"), resource_mock(name="cfg-2")],
+        ),
+    ],
 )
-def test_configmaps(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'ConfigMap', namespace, expected_namespace, expected_query, objects) as wrapper:
-        configmaps = wrapper.configmaps(name=name, **kwargs)
-        assert [r.obj for r in objects] == configmaps
+def test_configmaps(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "ConfigMap", namespace, objects)
+    configmaps = mock.wrapper.configmaps(name=name, **kwargs)
+    assert [r.obj for r in objects] == configmaps
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
 
 
 @pytest.mark.parametrize(
-    'kwargs,filter_kwargs,res',
+    "kwargs,filter_kwargs,res",
     [
         (
-            {}, {},
+            {},
+            {},
             [
-                resource_mock({'metadata': {'name': 'pvc-1'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'pvc-2'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'pvc-3'}, 'spec': {}, 'status': {}}),
-            ]
+                resource_mock(
+                    {"metadata": {"name": "pvc-1"}, "spec": {}, "status": {}}
+                ),
+                resource_mock(
+                    {"metadata": {"name": "pvc-2"}, "spec": {}, "status": {}}
+                ),
+                resource_mock(
+                    {"metadata": {"name": "pvc-3"}, "spec": {}, "status": {}}
+                ),
+            ],
         ),
         (
-            {'application': 'pvc-1', 'phase': 'Bound'}, {'selector': {'application': 'pvc-1'}},
-            [resource_mock({'metadata': {'name': 'pvc-1'}, 'spec': {}, 'status': {'phase': 'Bound'}})]
+            {"application": "pvc-1", "phase": "Bound"},
+            {"selector": {"application": "pvc-1"}},
+            [
+                resource_mock(
+                    {
+                        "metadata": {"name": "pvc-1"},
+                        "spec": {},
+                        "status": {"phase": "Bound"},
+                    }
+                )
+            ],
         ),
         (
-            {'name': 'pvc-2'}, {'field_selector': {'metadata.name': 'pvc-2'}},
-            [resource_mock({'metadata': {'name': 'pvc-2'}, 'spec': {}, 'status': {}})]
+            {"name": "pvc-2"},
+            {"field_selector": {"metadata.name": "pvc-2"}},
+            [resource_mock({"metadata": {"name": "pvc-2"}, "spec": {}, "status": {}})],
         ),
-    ]
+    ],
 )
 def test_persistentvolumeclaims(monkeypatch, kwargs, filter_kwargs, res):
     client_mock(monkeypatch)
@@ -437,8 +702,10 @@ def test_persistentvolumeclaims(monkeypatch, kwargs, filter_kwargs, res):
     query = persistentvolumeclaim.objects.return_value.filter.return_value
 
     monkeypatch.setattr(
-        'zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources', get_resources)
-    monkeypatch.setattr('pykube.PersistentVolumeClaim', persistentvolumeclaim)
+        "zmon_worker_monitor.builtins.plugins.kubernetes.KubernetesWrapper._get_resources",
+        get_resources,
+    )
+    monkeypatch.setattr("pykube.PersistentVolumeClaim", persistentvolumeclaim)
 
     k = KubernetesWrapper()
 
@@ -447,29 +714,42 @@ def test_persistentvolumeclaims(monkeypatch, kwargs, filter_kwargs, res):
     assert [r.obj for r in res] == persistentvolumeclaims
 
     get_resources.assert_called_with(query)
-    persistentvolumeclaim.objects.return_value.filter.assert_called_with(**filter_kwargs)
+    persistentvolumeclaim.objects.return_value.filter.assert_called_with(
+        **filter_kwargs
+    )
 
 
 @pytest.mark.parametrize(
-    'kwargs,filter_kwargs,res',
+    "kwargs,filter_kwargs,res",
     [
         (
-            {}, {},
+            {},
+            {},
             [
-                resource_mock({'metadata': {'name': 'pv-1'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'pv-2'}, 'spec': {}, 'status': {}}),
-                resource_mock({'metadata': {'name': 'pv-3'}, 'spec': {}, 'status': {}}),
-            ]
+                resource_mock({"metadata": {"name": "pv-1"}, "spec": {}, "status": {}}),
+                resource_mock({"metadata": {"name": "pv-2"}, "spec": {}, "status": {}}),
+                resource_mock({"metadata": {"name": "pv-3"}, "spec": {}, "status": {}}),
+            ],
         ),
         (
-            {'application': 'pv-1', 'phase': 'Bound'}, {'selector': {'application': 'pv-1'}},
-            [resource_mock({'metadata': {'name': 'pv-1'}, 'spec': {}, 'status': {'phase': 'Bound'}})]
+            {"application": "pv-1", "phase": "Bound"},
+            {"selector": {"application": "pv-1"}},
+            [
+                resource_mock(
+                    {
+                        "metadata": {"name": "pv-1"},
+                        "spec": {},
+                        "status": {"phase": "Bound"},
+                    }
+                )
+            ],
         ),
         (
-            {'name': 'pv-2'}, {'field_selector': {'metadata.name': 'pv-2'}},
-            [resource_mock({'metadata': {'name': 'pv-2'}, 'spec': {}, 'status': {}})]
+            {"name": "pv-2"},
+            {"field_selector": {"metadata.name": "pv-2"}},
+            [resource_mock({"metadata": {"name": "pv-2"}, "spec": {}, "status": {}})],
         ),
-    ]
+    ],
 )
 def test_persistentvolumes(monkeypatch, kwargs, filter_kwargs, res):
     client_mock(monkeypatch)
@@ -478,7 +758,7 @@ def test_persistentvolumes(monkeypatch, kwargs, filter_kwargs, res):
     query = persistentvolume.objects.return_value.filter.return_value
     query.all.return_value = res
 
-    monkeypatch.setattr('pykube.PersistentVolume', persistentvolume)
+    monkeypatch.setattr("pykube.PersistentVolume", persistentvolume)
 
     k = KubernetesWrapper()
 
@@ -490,77 +770,164 @@ def test_persistentvolumes(monkeypatch, kwargs, filter_kwargs, res):
 
 
 @pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
     [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='quota-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='quota-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='quota-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='quota-1'), resource_mock(name='quota-2')]),
-    ]
+        (None, pykube.all, "foo", {}, {"name": "foo"}, [resource_mock(name="quota-1")]),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="quota-1")],
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="quota-1")],
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="quota-1"), resource_mock(name="quota-2")],
+        ),
+    ],
 )
-def test_resourcequotas(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'ResourceQuota', namespace, expected_namespace, expected_query, objects) as wrapper:
-        resourcequotas = wrapper.resourcequotas(name=name, **kwargs)
-        assert [r.obj for r in objects] == resourcequotas
+def test_resourcequotas(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "ResourceQuota", namespace, objects)
+    resourcequotas = mock.wrapper.resourcequotas(name=name, **kwargs)
+    assert [r.obj for r in objects] == resourcequotas
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
 
 
 @pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
     [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='job-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='job-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='job-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='job-1'), resource_mock(name='job-2')]),
-    ]
+        (None, pykube.all, "foo", {}, {"name": "foo"}, [resource_mock(name="job-1")]),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="job-1")],
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="job-1")],
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="job-1"), resource_mock(name="job-2")],
+        ),
+    ],
 )
-def test_jobs(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'Job', namespace, expected_namespace, expected_query, objects) as wrapper:
-        jobs = wrapper.jobs(name=name, **kwargs)
-        assert [r.obj for r in objects] == jobs
+def test_jobs(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "Job", namespace, objects)
+    jobs = mock.wrapper.jobs(name=name, **kwargs)
+    assert [r.obj for r in objects] == jobs
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
 
 
 @pytest.mark.parametrize(
-    'namespace,expected_namespace,name,kwargs,expected_query,objects',
+    "namespace,expected_namespace,name,kwargs,expected_query,objects",
     [
-        (None, pykube.all, 'foo', {}, {'name': 'foo'}, [resource_mock(name='cronjob-1')]),
-        ('default', 'default', 'foo', {}, {'name': 'foo'}, [resource_mock(name='cronjob-1')]),
-        (None, pykube.all, None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='cronjob-1')]),
-        ('foobar', 'foobar', None, {'application': 'foo'}, {'name': None, 'application': 'foo'}, [resource_mock(name='cronjob-1'), resource_mock(name='cronjob-2')]),
-    ]
+        (
+            None,
+            pykube.all,
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="cronjob-1")],
+        ),
+        (
+            "default",
+            "default",
+            "foo",
+            {},
+            {"name": "foo"},
+            [resource_mock(name="cronjob-1")],
+        ),
+        (
+            None,
+            pykube.all,
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="cronjob-1")],
+        ),
+        (
+            "foobar",
+            "foobar",
+            None,
+            {"application": "foo"},
+            {"name": None, "application": "foo"},
+            [resource_mock(name="cronjob-1"), resource_mock(name="cronjob-2")],
+        ),
+    ],
 )
-def test_cronjobs(monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects):
-    with pykube_mock(monkeypatch, 'CronJob', namespace, expected_namespace, expected_query, objects) as wrapper:
-        cronjobs = wrapper.cronjobs(name=name, **kwargs)
-        assert [r.obj for r in objects] == cronjobs
+def test_cronjobs(
+    monkeypatch, namespace, expected_namespace, name, kwargs, expected_query, objects
+):
+    mock = MockWrapper(monkeypatch, "CronJob", namespace, objects)
+    cronjobs = mock.wrapper.cronjobs(name=name, **kwargs)
+    assert [r.obj for r in objects] == cronjobs
+    mock.assert_objects_called(expected_namespace=expected_namespace)
+    mock.assert_get_resources_called(expected_query)
 
 
 def test_metrics(monkeypatch):
     client = client_mock(monkeypatch)
 
     resp = MagicMock()
-    resp.text = 'metrics'
+    resp.text = "metrics"
 
     client.return_value.session.get.return_value = resp
 
     parsed = MagicMock()
     parsed.samples = [
-        ('metric-1', {}, 20.17), ('metric-2', {'verb': 'GET'}, 20.16), ('metric-1', {'verb': 'POST'}, 20.18)
+        ("metric-1", {}, 20.17),
+        ("metric-2", {"verb": "GET"}, 20.16),
+        ("metric-1", {"verb": "POST"}, 20.18),
     ]
 
     parser = MagicMock()
     parser.return_value = [parsed]
 
-    monkeypatch.setattr('zmon_worker_monitor.builtins.plugins.kubernetes.text_string_to_metric_families', parser)
+    monkeypatch.setattr(
+        "zmon_worker_monitor.builtins.plugins.kubernetes.text_string_to_metric_families",
+        parser,
+    )
 
     k = KubernetesWrapper()
     metrics = k.metrics()
 
     expected = {
-        'metric-1': [({}, 20.17), ({'verb': 'POST'}, 20.18)],
-        'metric-2': [({'verb': 'GET'}, 20.16)],
+        "metric-1": [({}, 20.17), ({"verb": "POST"}, 20.18)],
+        "metric-2": [({"verb": "GET"}, 20.16)],
     }
 
     assert metrics == expected
 
     parser.assert_called_with(resp.text)
-    client.return_value.session.get.assert_called_with(CLUSTER_URL + '/metrics')
+    client.return_value.session.get.assert_called_with(CLUSTER_URL + "/metrics")

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -59,6 +59,7 @@ class MockWrapper:
 def client_mock(monkeypatch):
     monkeypatch.setattr("pykube.KubeConfig", MagicMock())
     client = MagicMock(name="client")
+    client.config.cluster = {'server': CLUSTER_URL}
     monkeypatch.setattr("pykube.HTTPClient", lambda *args, **kwargs: client)
     return client
 
@@ -1028,7 +1029,7 @@ def test_metrics(monkeypatch):
     resp = MagicMock()
     resp.text = "metrics"
 
-    client.return_value.session.get.return_value = resp
+    client.session.get.return_value = resp
 
     parsed = MagicMock()
     parsed.samples = [
@@ -1056,4 +1057,4 @@ def test_metrics(monkeypatch):
     assert metrics == expected
 
     parser.assert_called_with(resp.text)
-    client.return_value.session.get.assert_called_with(CLUSTER_URL + "/metrics")
+    client.session.get.assert_called_with(CLUSTER_URL + "/metrics")

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -42,7 +42,7 @@ class MockWrapper:
         )
 
         self._client = client_mock(monkeypatch)
-        self.wrapper = KubernetesWrapper(namespace=namespace)
+        self.wrapper = KubernetesWrapper(namespace=namespace, check_id='<test>')
 
     def assert_objects_called(self, expected_namespace=None):
         if expected_namespace is not None:
@@ -224,7 +224,7 @@ def test_pods(
 
 @pytest.mark.parametrize("kwargs", ({"ready": 1}, {"ready": 0}, {"phase": "WRONG"}))
 def test_pods_error(kwargs):
-    k = KubernetesWrapper()
+    k = KubernetesWrapper(check_id='<test>')
 
     with pytest.raises(CheckError):
         k.pods(**kwargs)
@@ -239,7 +239,7 @@ def test_namespaces(monkeypatch):
     ns.objects.return_value.all.return_value = res
     monkeypatch.setattr("pykube.Namespace", ns)
 
-    k = KubernetesWrapper()
+    k = KubernetesWrapper(check_id='<test>')
     namespaces = k.namespaces()
 
     assert [r.obj for r in res] == namespaces
@@ -692,7 +692,7 @@ def test_deployments(
 
 @pytest.mark.parametrize("kwargs", ({"ready": 1}, {"ready": 0}))
 def test_deployments_error(kwargs):
-    k = KubernetesWrapper()
+    k = KubernetesWrapper(check_id='<test>')
 
     with pytest.raises(CheckError):
         k.deployments(**kwargs)
@@ -1046,7 +1046,7 @@ def test_metrics(monkeypatch):
         parser,
     )
 
-    k = KubernetesWrapper()
+    k = KubernetesWrapper(check_id='<test>')
     metrics = k.metrics()
 
     expected = {

--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -79,19 +79,9 @@ class KubernetesWrapper(object):
         :return: List of pykube resources.
         :rtype: list
         """
-        resources = []
 
-        # check if we need resources for all namespaces.
-        if self.__namespace is None:
-            namespaces = self.namespaces()
-
-            for namespace in namespaces:
-                ns = namespace['metadata']['name']
-                resources += list(query.filter(namespace=ns))
-        else:
-            resources = list(query.filter(namespace=self.__namespace))
-
-        return resources
+        namespace = pykube.all if self.__namespace is None else self.__namespace
+        return list(query.filter(namespace=namespace))
 
     def namespaces(self):
         """

--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -40,6 +40,9 @@ class KubernetesFactory(IFunctionFactoryPlugin):
 
 def _get_resources(object_manager, name=None, phase=None, **kwargs):
     if name is not None:
+        if object_manager.namespace == pykube.all:
+            raise CheckError("namespace is required for name= queries")
+
         if phase is not None or kwargs:
             raise CheckError("name= query doesn't support additional filters")
 

--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -37,7 +37,7 @@ class KubernetesFactory(IFunctionFactoryPlugin):
         :param factory_ctx: (dict) names available for Function instantiation
         :return: an object that implements a check function
         """
-        return propartial(KubernetesWrapper)
+        return propartial(KubernetesWrapper, check_id=factory_ctx['check_id'], __protected=['check_id'])
 
 
 def _get_resources(object_manager, name=None, field_selector=None, **kwargs):
@@ -66,14 +66,15 @@ def _get_resources(object_manager, name=None, field_selector=None, **kwargs):
 
 
 class KubernetesWrapper(object):
-    def __init__(self, namespace='default'):
+    def __init__(self, check_id, namespace='default'):
+        self.__check_id = check_id
         self.__namespace = pykube.all if namespace is None else namespace
 
     @property
     def __client(self):
         config = pykube.KubeConfig.from_service_account()
         client = pykube.HTTPClient(config)
-        client.session.headers['User-Agent'] = get_user_agent()
+        client.session.headers['User-Agent'] = "{} (check {})".format(get_user_agent(), self.__check_id)
         client.session.trust_env = False
         return client
 

--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -9,6 +9,8 @@ from collections import defaultdict
 
 from prometheus_client.parser import text_string_to_metric_families
 
+from zmon_worker_monitor.zmon_worker.common.http import get_user_agent
+
 from zmon_worker_monitor.zmon_worker.errors import CheckError
 
 from zmon_worker_monitor.adapters.ifunctionfactory_plugin import IFunctionFactoryPlugin, propartial
@@ -72,6 +74,7 @@ class KubernetesWrapper(object):
     def __client(self):
         config = pykube.KubeConfig.from_service_account()
         client = pykube.HTTPClient(config)
+        client.session.headers['User-Agent'] = get_user_agent()
         client.session.trust_env = False
         return client
 

--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -206,7 +206,7 @@ class KubernetesWrapper(object):
         :return: List of Statefulsets. Typical Statefulset has "metadata", "status" and "spec".
         :rtype: list
         """
-        statfulsets = _get_resources(pykube.StatefulSet.objects(self.__client, namespace=self.__namespace),
+        statfulsets = _get_resources(pykube.StatefulSet.objects(self.__client, self.__namespace),
                                      name=name, **kwargs)
 
         return [statfulset.obj for statfulset in statfulsets if replicas is None or statfulset.replicas == replicas]


### PR DESCRIPTION
* When querying objects in all namespaces send just 1 request instead of manually enumerating objects in all namespaces.
* Use `GET` instead of `LIST` with a field selector for queries that have a `name`.
* Set the User-Agent correctly for Kubernetes API requests.