### PR TITLE
Do not retry on read timeout

### DIFF
--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -977,8 +977,9 @@ class MainTask(object):
                             r.raise_for_status()
                         except requests.exceptions.ReadTimeout:
                             logger.warning(
-                                "Request to Data Service exceeded read timeout: %d. Not retrying...",
-                                timeout
+                                "Request to Data Service exceeded read timeout: %d. Not retrying... Data: %s",
+                                timeout,
+                                serialized_data
                             )
                             current_span.set_tag('dataservice_read_timeout', True)
         except Exception as ex:

--- a/zmon_worker_monitor/zmon_worker/tasks/main.py
+++ b/zmon_worker_monitor/zmon_worker/tasks/main.py
@@ -976,7 +976,10 @@ class MainTask(object):
                             r = requests.put(url, data=serialized_data, timeout=timeout, headers=headers)
                             r.raise_for_status()
                         except requests.exceptions.ReadTimeout:
-                            logger.warning("Request to Data Service exceeded read timeout: %d. Not retrying...", timeout)
+                            logger.warning(
+                                "Request to Data Service exceeded read timeout: %d. Not retrying...",
+                                timeout
+                            )
                             current_span.set_tag('dataservice_read_timeout', True)
         except Exception as ex:
             logger.error('Error in data service send: url={} ex={}'.format(cls._dataservice_url, ex))


### PR DESCRIPTION
**Context**
During the [incident](https://docs.google.com/document/d/1EsKMN28CLXj16b9zQoVpoU3wqGKY77uyZp1jm4U1Txs/edit#) Data Service started responding very slowly at some point in time and zmon-worker could not push check results to it initially because of `Read time out` (connection established, HTTP request sent over the wire, not response emitted from Data Service) - it did not respond in 10 seconds.
After that zmon-worker initiated all the retry logic which overloaded Data Service even more which resulted in even slower responses.

When looking at [traces](https://app.lightstep.com/Production/stream/component-zmon-worker-operation-send_to_dataservice/8FRb64Qn?range=2160&trace_bundle=EgYIwLGG7gUaBgiwwobuBSIIOEZSYjY0UW4%3D&anchor=1572970800) `Read time out` does not mean Data Service does not do the job or aborts. Most of the times data points make it to the KairosDB even though HTTP request was not finished from zmon-worker perspective. Due to considering `Read time out` as error request to Data Service is retried which results in duplicates and unnecessary load on Data Service.

**Scope**
Do not treat `Read time out` as error on zmon-worker side and thus do not retry it

**Risks**
_Please assess carefully!_
However this change does not come risk free.
There is no guarantee, persistent queue or confirmation logic on Data Service side so we are pushing to it on the best effort basis (assuming that when connection was established and request was sent everything will eventually go through) and can **introduce some unexpected data drops due to a lack of retries (in case where asynchronous processing on Data Service side was somehow disturbed)**.
Decision needs to be taken if this is fine.

**Additions**
Number of retries (configurable on zmon-worker side) can be reduced along with this change or instead of it.