### PR TITLE
kubernetes: use a kwarg for check_id

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -66,7 +66,7 @@ def _get_resources(object_manager, name=None, field_selector=None, **kwargs):
 
 
 class KubernetesWrapper(object):
-    def __init__(self, check_id, namespace='default'):
+    def __init__(self, check_id='<unknown>', namespace='default'):
         self.__check_id = check_id
         self.__namespace = pykube.all if namespace is None else namespace
 


### PR DESCRIPTION
`propartial` doesn't raise any errors if a protected argument is not a keyword one, but it won't be handled correctly. Users that do `kubernetes('foo')` instead of `kubernetes(namespace='foo')` will not get any results.