### PR TITLE
kubernetes: namespace has to be first for no-kwargs form to work

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -66,7 +66,7 @@ def _get_resources(object_manager, name=None, field_selector=None, **kwargs):
 
 
 class KubernetesWrapper(object):
-    def __init__(self, check_id='<unknown>', namespace='default'):
+    def __init__(self, namespace='default', check_id='<unknown>'):
         self.__check_id = check_id
         self.__namespace = pykube.all if namespace is None else namespace
 


### PR DESCRIPTION
`propartial()` doesn't fix stuff like this for us, so we have to be more explicit.