### PR TITLE
TimeWrapper Timezone Support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,5 @@ setproctitle==1.1.10
 stups-tokens>=1.0.14,<2
 subprocess32==3.5.2
 timeperiod2==0.1
+tzlocal==2.0.0
 Yapsy==1.11.223

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,9 +1,12 @@
 from datetime import datetime
 
 import pytest
+import pytz
 from mock import MagicMock
 
 from zmon_worker_monitor.builtins.plugins.time_ import TimeWrapper
+
+BERLIN_TZ = pytz.timezone('Europe/Berlin')
 
 
 def test_now_isoformat(monkeypatch):
@@ -16,7 +19,8 @@ def test_now_isoformat(monkeypatch):
 @pytest.mark.parametrize('inp,out', [
     ({'spec': 1467284283}, datetime.fromtimestamp(1467284283)),
     ({'spec': 1467284283.145063}, datetime.fromtimestamp(1467284283.145063)),
-    ({'spec': 1467284283, 'utc': True}, datetime.utcfromtimestamp(1467284283))
+    ({'spec': 1467284283, 'utc': True}, datetime.utcfromtimestamp(1467284283)),
+    ({'spec': 14672842, 'tz_name': 'Europe/Berlin'}, datetime.fromtimestamp(14672842, BERLIN_TZ))
 ])
 def test_time_epoch(monkeypatch, inp, out):
     tw = TimeWrapper(**inp)
@@ -28,3 +32,13 @@ def test_time_sub(monkeypatch):
     tw2 = TimeWrapper('2016-01-01 00:00:59')
 
     assert 59 == tw2 - tw1
+
+
+def test_raise_error_if_utc_and_tz_given(monkeypatch):
+    with pytest.raises(ValueError):
+        TimeWrapper(0, True, 'Europe/Berlin')
+
+
+def test_init_timezone():
+    berlin_now = TimeWrapper(tz_name='Europe/Berlin').time
+    assert (berlin_now - datetime.now(BERLIN_TZ)).total_seconds() < 1

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -34,7 +34,7 @@ def test_time_sub(monkeypatch):
     assert 59 == tw2 - tw1
 
 
-def test_raise_error_if_utc_and_tz_given(monkeypatch):
+def test_raise_error_if_utc_and_tz_given():
     with pytest.raises(ValueError):
         TimeWrapper(0, True, 'Europe/Berlin')
 
@@ -42,3 +42,8 @@ def test_raise_error_if_utc_and_tz_given(monkeypatch):
 def test_init_timezone():
     berlin_now = TimeWrapper(tz_name='Europe/Berlin').time
     assert (berlin_now - datetime.now(BERLIN_TZ)).total_seconds() < 1
+
+
+def test_astimezone():
+    tw = TimeWrapper('2016-01-01 01:00:00', utc=True)
+    assert tw.astimezone('Europe/Berlin').isoformat() == '2016-01-01 02:00:00+01:00'

--- a/zmon_worker_monitor/builtins/plugins/time_.py
+++ b/zmon_worker_monitor/builtins/plugins/time_.py
@@ -41,7 +41,12 @@ class TimeWrapper(object):
             raise ValueError('Ambiguous time zone. Do not use "utc" and "tz_name" parameter at the same time.')
 
         tz = pytz.timezone(tz_name) if tz_name else None
-        self.timezone = pytz.UTC if utc else tz if tz_name else tzlocal.get_localzone()
+        if utc:
+            self.timezone = pytz.UTC
+        elif tz_name:
+            self.timezone = tz
+        else:
+            self.timezone = tzlocal.get_localzone()
 
         if isinstance(spec, Number):
             self.time = datetime.utcfromtimestamp(spec) if utc else datetime.fromtimestamp(spec, tz)

--- a/zmon_worker_monitor/builtins/plugins/time_.py
+++ b/zmon_worker_monitor/builtins/plugins/time_.py
@@ -79,7 +79,7 @@ class TimeWrapper(object):
 
     def astimezone(self, tz_name):
         '''
-        >>> TimeWrapper('2014-01-01 01:01', tz_name='UTC').astimezone('Europe/Berlin')
+        >>> TimeWrapper('2014-01-01 01:01', tz_name='UTC').astimezone('Europe/Berlin').isoformat()
         '2014-01-01 02:01:00+01:00'
         '''
         tz = pytz.timezone(tz_name)


### PR DESCRIPTION
ZMON workers currently lack the ability to convert timestamps into different timezones which makes it hard to compare timestamps with thresholds like 6am in Berlin's local time.

This PR tries to fix this problem by adding:
- a new constructor parameter `tz_name`
- a method `astimestamp`
- tests