### PR TITLE
use killpg to kill workers

### DIFF
--- a/zmon_worker_monitor/process_controller.py
+++ b/zmon_worker_monitor/process_controller.py
@@ -516,7 +516,7 @@ class ProcessPlus(Process):
                 time.sleep(kill_wait)
                 if self.is_alive():
                     self.logger.warn('Sending SIGKILL to process with pid=%s', self.pid)
-                    os.kill(int(self.pid), signal.SIGKILL)
+                    os.killpg(int(self.pid), signal.SIGKILL)
                     time.sleep(0.1)
                 assert not self.is_alive(), 'Fatal: Process {} alive after SIGKILL'.format(self.name)
             else:


### PR DESCRIPTION
`killpg` will kill not just the worker but also any subprocess under it. Currently a check that starts another process (eg. `exasol()`) which runs longer then interval will timeout, which will cause worker monitor to kill worker process but not the hcild. The child will be orphaned and remain in the system indefinitely.