### PR TITLE
Revert "use killpg to kill workers"

### DIFF
--- a/zmon_worker_monitor/process_controller.py
+++ b/zmon_worker_monitor/process_controller.py
@@ -516,7 +516,7 @@ class ProcessPlus(Process):
                 time.sleep(kill_wait)
                 if self.is_alive():
                     self.logger.warn('Sending SIGKILL to process with pid=%s', self.pid)
-                    os.killpg(int(self.pid), signal.SIGKILL)
+                    os.kill(int(self.pid), signal.SIGKILL)
                     time.sleep(0.1)
                 assert not self.is_alive(), 'Fatal: Process {} alive after SIGKILL'.format(self.name)
             else:


### PR DESCRIPTION
Reverts zalando-zmon/zmon-worker#426

... without creating a process group, this will probably not do what it was intended for