### PR TITLE
Allow user defined threading behaviour for Google chat notifications

### DIFF
--- a/tests/test_google_hangouts_chat_notifications.py
+++ b/tests/test_google_hangouts_chat_notifications.py
@@ -1,5 +1,7 @@
 from mock import MagicMock
 
+from datetime import datetime
+
 from zmon_worker_monitor.zmon_worker.notifications.google_hangouts_chat import NotifyGoogleHangoutsChat
 
 
@@ -16,9 +18,9 @@ def test_google_hangouts_chat_notification(monkeypatch):
 
     alert = {'changed': True, 'is_alert': True, 'alert_def': {'id': 123, 'name': 'alert'}, 'entity': {'id': 'e-1'}}
 
-    r = NotifyGoogleHangoutsChat.notify(alert,
-                                        message='ALERT',
-                                        webhook_link='http://chat.example.org/v1/spaces/XYZ/messages?key=123&token=ABC')
+    URL = 'http://chat.example.org/v1/spaces/XYZ/messages?threadKey={}&key=123&token=ABC'
+
+    webhook_link = 'http://chat.example.org/v1/spaces/XYZ/messages?key=123&token=ABC'
 
     data = {
         "cards": [{
@@ -39,8 +41,33 @@ def test_google_hangouts_chat_notification(monkeypatch):
         }]
     }
 
+    r = NotifyGoogleHangoutsChat.notify(alert,
+                                        message='ALERT',
+                                        webhook_link=webhook_link)
+
     assert r == 0
+    post.assert_called_with(URL.format("123"), json=data, headers=HEADERS, timeout=5)
 
-    URL = 'http://chat.example.org/v1/spaces/XYZ/messages?threadKey=123&key=123&token=ABC'
+    r2 = NotifyGoogleHangoutsChat.notify(alert,
+                                         message='ALERT',
+                                         threading='alert-date',
+                                         webhook_link=webhook_link)
 
-    post.assert_called_with(URL, json=data, headers=HEADERS, timeout=5)
+    assert r2 == 0
+    date = str(datetime.date(datetime.now()))
+    post.assert_called_with(URL.format("123" + date), json=data, headers=HEADERS, timeout=5)
+
+    r3 = NotifyGoogleHangoutsChat.notify(alert,
+                                         message='ALERT',
+                                         threading='date',
+                                         webhook_link=webhook_link)
+    assert r3 == 0
+    post.assert_called_with(URL.format(date), json=data, headers=HEADERS, timeout=5)
+
+    r4 = NotifyGoogleHangoutsChat.notify(alert,
+                                         message='ALERT',
+                                         threading='none',
+                                         webhook_link=webhook_link)
+
+    assert r4 == 0
+    post.assert_called_with(webhook_link, json=data, headers=HEADERS, timeout=5)


### PR DESCRIPTION
Adds a `threading` param for Google Notifications with the following behaviours:

- `alert`: Current behaviour (default). One thread per alert ID
- `date`: One thread per day
- `alert-date`: One thread per alert per day
- `none`: No threading at all

Fixes #374 