### PR TITLE
Monkey-patch pykube to be compatible with 1.16

### DIFF
--- a/zmon_worker_monitor/builtins/plugins/kubernetes.py
+++ b/zmon_worker_monitor/builtins/plugins/kubernetes.py
@@ -19,6 +19,14 @@ VALID_PHASE = ('Pending', 'Running', 'Failed', 'Succeeded', 'Unknown')
 
 logger = logging.getLogger('zmon-worker.kubernetes-function')
 
+# TODO Monkey-patch pykube to be compatible with Kubernetes 1.16.
+# Drop if pykube is updated to a still maintained version.
+pykube.objects.Deployment.version = 'apps/v1'
+pykube.objects.StatefulSet.version = 'apps/v1'
+pykube.objects.ReplicaSet.version = 'apps/v1'
+pykube.objects.DaemonSet.version = 'apps/v1'
+pykube.objects.CronJob.version = 'batch/v1beta1'
+
 
 class KubernetesFactory(IFunctionFactoryPlugin):
     def __init__(self):


### PR DESCRIPTION
ZMON still uses a very old Python version, so it's impossible to update pykube to a version that's compatible with 1.16. Let's just monkey-patch its objects instead.