### PR TITLE
fix: too large captures for opsgenie

### DIFF
--- a/tests/test_opsgenie_notification.py
+++ b/tests/test_opsgenie_notification.py
@@ -174,7 +174,7 @@ def test_opsgenie_notification_captures(monkeypatch, include_captures, is_alert,
     params = {}
 
     if include_captures:
-        details = {'alert_evaluation_ts': 1234, 'foo': 'bar'}
+        details = {'alert_evaluation_ts': 1234, 'captures.foo': 'bar'}
     else:
         details = {'alert_evaluation_ts': 1234}
 


### PR DESCRIPTION
we limit the amount of captures being sent to opsgenie to half of
the max payload size - the rest is small and should not exceed 1-2kB
in normal usage. The captures are visible in the alert detail
page also. The include_captures=True is a convenience feature. It is
better to drop the captures than not to send out the page